### PR TITLE
Updated celo-fullnode

### DIFF
--- a/charts/celo-fullnode/Chart.yaml
+++ b/charts/celo-fullnode/Chart.yaml
@@ -17,11 +17,11 @@ keywords:
   - Validator
   - Ethereum
   - Proof-of-Stake
-version: 0.4.3
+version: 0.4.4
 dependencies:
   - name: common
     repository: oci://us-west1-docker.pkg.dev/devopsre/clabs-public-oci
-    version: 0.2.2
+    version: 0.2.3
 maintainers:
   - name: cLabs
     email: devops@clabs.co

--- a/charts/celo-fullnode/templates/_helpers.tpl
+++ b/charts/celo-fullnode/templates/_helpers.tpl
@@ -3,8 +3,8 @@
 Expand the name of the chart.
 */}}
 {{- define "celo-fullnode.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
 
 {{/*
 Create a default fully qualified app name.
@@ -12,24 +12,24 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "celo-fullnode.fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
 
 {{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "celo-fullnode.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
 
 {{- define "celo-fullnode.rpc-ports" -}}
 - port: 8545
@@ -40,7 +40,7 @@ Create chart name and version as used by the chart label.
   targetPort: ws
   protocol: TCP
   name: ws
-{{- end -}}
+{{- end }}
 
 {{/*
  * The easiest way to get the public IP for the node (VM) that a EKS pod is on
@@ -48,24 +48,24 @@ Create chart name and version as used by the chart label.
  * from the downward k8s API.
 */}}
 {{- define "celo-fullnode.aws-subnet-specific-nat-ip" -}}
-{{- if .Values.aws -}}
+{{- if .Values.aws }}
 PUBLIC_IP=$(wget https://ipinfo.io/ip -O - -q)
 NAT_FLAG="--nat=extip:${PUBLIC_IP}"
-{{- end -}}
-{{- end -}}
+{{- end }}
+{{- end }}
 
 {{/*
  * Blockscout indexer requests can take longer than default
  * request timeouts.
  * Adding a dummy comment (template .extra_setup) because helm indenting problems if this template is empty
 */}}
-{{- define "celo-fullnode.extra_setup" }}
+{{- define "celo-fullnode.extra_setup" -}}
 # template .extra_setup
 {{- include  "celo-fullnode.aws-subnet-specific-nat-ip" . }}
 {{- if .Values.geth.increase_timeouts }}
 ADDITIONAL_FLAGS="${ADDITIONAL_FLAGS} --http.timeout.read 600 --http.timeout.write 600 --http.timeout.idle 2400"
-{{- end -}}
-{{- end -}}
+{{- end }}
+{{- end }}
 
 {{/*
  * This will create an HTTP server at .server_port
@@ -92,4 +92,4 @@ ADDITIONAL_FLAGS="${ADDITIONAL_FLAGS} --http.timeout.read 600 --http.timeout.wri
     subPath: health-check.sh
   - name: data-shared
     mountPath: /data-shared
-{{- end -}}
+{{- end }}

--- a/charts/celo-fullnode/templates/healthcheck-cm.yaml
+++ b/charts/celo-fullnode/templates/healthcheck-cm.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: {{ template "common.fullname" . }}-health-check
   labels:
-{{ include "common.standard.labels" .  | indent 4 }}
+    {{- include "common.standard.labels" .  | nindent 4 }}
     component: health-check-config-map
   namespace: {{ .Release.Namespace }}
 data:

--- a/charts/celo-fullnode/templates/hpa.yaml
+++ b/charts/celo-fullnode/templates/hpa.yaml
@@ -4,7 +4,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "common.fullname" . }}
   labels:
-{{ include "common.standard.labels" .  | indent 4 }}
+    {{- include "common.standard.labels" .  | nindent 4 }}
     component: celo-fullnode
 spec:
   minReplicas: {{ .Values.geth.autoscaling.minReplicas }}
@@ -13,8 +13,12 @@ spec:
     apiVersion: apps/v1
     kind: StatefulSet
     name: {{ template "common.fullname" . }}
+  {{- with .Values.geth.autoscaling.metrics }}
   metrics:
-    {{- toYaml .Values.geth.autoscaling.metrics | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.geth.autoscaling.behavior }}
   behavior:
-    {{- toYaml .Values.geth.autoscaling.behavior | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end -}}

--- a/charts/celo-fullnode/templates/individual-pod-svc.yaml
+++ b/charts/celo-fullnode/templates/individual-pod-svc.yaml
@@ -1,26 +1,27 @@
-{{ range $index, $e := until (int .Values.replicaCount ) }}
+{{- $replicas := ternary .Values.geth.autoscaling.maxReplicas .Values.replicaCount .Values.geth.autoscaling.enabled }}
+{{ range $index, $e := until (int $replicas ) }}
 {{ range $protocolIndex, $protocol := $.Values.geth.service_protocols }}
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "common.fullname" $ }}-{{ $index }}-{{ lower $protocol }}
+  {{- if $.Values.azure }}
   annotations:
-{{ if $.Values.azure }}
     service.beta.kubernetes.io/azure-load-balancer-mixed-protocols: "true"
-{{ end }}
+  {{- end }}
   labels:
-{{ include "common.standard.labels" $ | indent 4 }}
+    {{- include "common.standard.labels" $ | nindent 4 }}
     component: celo-fullnode-protocol-traffic
 spec:
   type: {{ $.Values.geth.service_type }}
   publishNotReadyAddresses: true
-{{- if (and (eq $.Values.geth.service_type "LoadBalancer") (gt (len $.Values.geth.public_ip_per_node) $index)) }}
+  {{- if (and (eq $.Values.geth.service_type "LoadBalancer") (gt (len $.Values.geth.public_ip_per_node) $index)) }}
   loadBalancerIP: {{ index $.Values.geth.public_ip_per_node $index -}}
-{{- end }}
+  {{- end }}
   ports:
-{{- if $.Values.geth.service_node_port_per_full_node }}
-{{- $port := index $.Values.geth.service_node_port_per_full_node $index }}
+    {{- if $.Values.geth.service_node_port_per_full_node }}
+    {{- $port := index $.Values.geth.service_node_port_per_full_node $index }}
     - targetPort: {{ $port }}
       port: {{ $port }}
       nodePort: {{ $port }}
@@ -31,16 +32,16 @@ spec:
       nodePort: {{ $port }}
       name: udp
       protocol: UDP
-{{- else }}
+    {{- else }}
     - port: 30303
       targetPort: ethereum
       name: ethereum
       protocol: {{ $protocol }}
-{{- end }}
-{{- if $.Values.geth.expose_rpc_externally }}
-{{ include "celo-fullnode.rpc-ports" . | indent 4 }}
-{{- end }}
+    {{- end }}
+    {{- if $.Values.geth.expose_rpc_externally }}
+    {{- include "celo-fullnode.rpc-ports" . | nindent 4 }}
+    {{- end }}
   selector:
     statefulset.kubernetes.io/pod-name: {{ template "common.fullname" $ }}-{{ $index }}
-{{ end }}
-{{ end }}
+{{- end }}
+{{- end }}

--- a/charts/celo-fullnode/templates/rpc-shared-svc.yaml
+++ b/charts/celo-fullnode/templates/rpc-shared-svc.yaml
@@ -3,17 +3,17 @@ kind: Service
 metadata:
   name: {{ template "common.fullname" . }}-rpc
   labels:
-{{ include "common.standard.labels" .  | indent 4 }}
+    {{- include "common.standard.labels" .  | nindent 4 }}
     component: celo-fullnode-rpc-traffic
   annotations:
-{{ if .Values.geth.create_network_endpoint_group }}
+    {{- if .Values.geth.create_network_endpoint_group }}
     cloud.google.com/neg: '{"exposed_ports": {"8545":{},"8546":{}}}'
-{{ end }}
+    {{- end }}
 spec:
   type: ClusterIP
   sessionAffinity: {{ default "None" .Values.geth.service_session_affinity }}
   ports:
-{{ include "celo-fullnode.rpc-ports" . | indent 4 }}
+  {{- include "celo-fullnode.rpc-ports" . | nindent 4 }}
   selector:
-{{ include "common.standard.short_labels" .  | indent 4 }}
+    {{- include "common.standard.short_labels" .  | nindent 4 }}
     component: celo-fullnode

--- a/charts/celo-fullnode/templates/sts.yaml
+++ b/charts/celo-fullnode/templates/sts.yaml
@@ -3,107 +3,100 @@ kind: StatefulSet
 metadata:
   name: {{ template "common.fullname" . }}
   labels:
-{{ include "common.standard.labels" .  | indent 4 }}
+    {{- include "common.standard.labels" .  | nindent 4 }}
     component: celo-fullnode
 spec:
   {{- if .Values.storage.enable }}
   volumeClaimTemplates:
   - metadata:
       name: data
+      {{- with .Values.storage.annotations }}
       annotations:
-        {{- toYaml .Values.storage.annotations | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       storageClassName: {{ .Values.storage.storageClass }}
       accessModes: [ "{{ .Values.storage.accessModes }}" ]
       resources:
         requests:
           storage: {{ .Values.storage.size }}
-      {{- if .Values.storage.snapshot.enabled | default false }}
+      {{- with .Values.storage.dataSource }}
       dataSource:
-        apiGroup: snapshot.storage.k8s.io
-        kind: {{ .Values.storage.snapshot.kind | default "VolumeSnapshot" }}
-        name: {{ .Values.storage.snapshot.name }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
   {{- end }}
   podManagementPolicy: Parallel
   updateStrategy:
-{{ toYaml .Values.geth.updateStrategy | indent 4 }}
+    {{- toYaml .Values.geth.updateStrategy | nindent 4 }}
+  {{- if not .Values.geth.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   serviceName: {{ template "common.fullname" . }}
   selector:
     matchLabels:
-{{ include "common.standard.labels" .  | indent 6 }}
+      {{- include "common.standard.labels" .  | nindent 6 }}
       component: celo-fullnode
   template:
     metadata:
       labels:
         {{- include "common.standard.labels" .  | nindent 8 }}
         {{- if .Values.extraPodLabels }}
-        {{ toYaml .Values.extraPodLabels | nindent 8 }}
+        {{- toYaml .Values.extraPodLabels | nindent 8 }}
         {{- end }}
         component: celo-fullnode
-{{- if .Values.metrics | default true }}
+      {{- if .Values.metrics | default true }}
       annotations:
-{{ include "common.prometheus-annotations" . | indent 8 }}
-{{ end }}
-    spec:
-{{- if .Values.geth.use_gstorage_data | default false }}
-      serviceAccountName: gcloud-storage-access
-{{- end }}
-      # see https://www.verygoodsecurity.com/blog/posts/kubernetes-multi-az-deployments-using-pod-anti-affinity
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: component
-                  operator: In
-                  values:
-                  - celo-fullnode
-              topologyKey: failure-domain.beta.kubernetes.io/zone
-            weight: 100
-      {{- if .Values.nodeSelector }}
-      nodeSelector:
-{{ toYaml .Values.nodeSelector | indent 8 }}
+        {{- include "common.prometheus-annotations" . | nindent 8 }}
       {{- end }}
-      {{- if .Values.tolerations }}
+    spec:
+      {{- if .Values.geth.use_gstorage_data | default false }}
+      serviceAccountName: gcloud-storage-access
+      {{- end }}
+      {{- with .Values.geth.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
       tolerations:
-{{ toYaml .Values.tolerations | indent 8 }}
+        {{- toYaml . | indent 8 }}
       {{- end }}
       initContainers:
-{{- if .Values.geth.use_gstorage_data | default false }}
-{{ include "common.remove-old-chaindata" . | indent 6 }}
-{{ include "common.gsutil-sync-data-init-container" . | indent 6 }}
-{{- end }}
-{{ include "common.conditional-init-genesis-container" .  | indent 6 }}
-{{- if .Values.geth.node_keys }}
-      - name: set-node-key
-        image: alpine:3.12
-        command:
-        - /bin/sh
-        - -c
-        args:
-        - |
-            RID=$(echo $REPLICA_NAME | grep -Eo '[0-9]+$')
-            NODE_KEYS={{ join "," .Values.geth.node_keys }}
-            NODE_KEY=$(echo -n $NODE_KEYS | cut -d ',' -f $((RID + 1)))
-            echo -n $NODE_KEY > /root/.celo/pkey
-        volumeMounts:
-        - name: data
-          mountPath: /root/.celo
-        env:
-        - name: REPLICA_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-{{ end }}
+      {{- if .Values.geth.use_gstorage_data | default false }}
+        {{- include "common.remove-old-chaindata" . | nindent 8 }}
+        {{- include "common.gsutil-sync-data-init-container" . | nindent 8 }}
+      {{- end }}
+        {{- include "common.conditional-init-genesis-container" .  | nindent 8 }}
+      {{- if .Values.geth.node_keys }}
+        - name: set-node-key
+          image: alpine:3.12
+          command:
+          - /bin/sh
+          - -c
+          args:
+          - |
+              RID=$(echo $REPLICA_NAME | grep -Eo '[0-9]+$')
+              NODE_KEYS={{ join "," .Values.geth.node_keys }}
+              NODE_KEY=$(echo -n $NODE_KEYS | cut -d ',' -f $((RID + 1)))
+              echo -n $NODE_KEY > /root/.celo/pkey
+          volumeMounts:
+          - name: data
+            mountPath: /root/.celo
+          env:
+          - name: REPLICA_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+      {{- end }}
       containers:
-{{ include "common.full-node-container" (dict "Values" $.Values "Release" $.Release "Chart" $.Chart "expose" true "ip_addresses" .Values.geth.public_ip_per_node "syncmode" .Values.geth.syncmode "gcmode" .Values.geth.gcmode "rpc_apis" .Values.geth.rpc_apis "pprof" (or (.Values.metrics) (.Values.pprof.enabled)) "pprof_port" (.Values.pprof.port) "metrics" (or (.Values.metrics) (.Values.metrics)) "ports" .Values.geth.service_node_port_per_full_node "light_serve" .Values.geth.light.serve "light_maxpeers" .Values.geth.light.maxpeers "maxpeers" .Values.geth.maxpeers "geth_flags" (.Values.geth.flags | default "") "extra_setup" (include "celo-fullnode.extra_setup" .)) | indent 6 }}
-{{ if .Values.geth.create_network_endpoint_group }}
-{{ include "celo-fullnode.health-checker-server" (dict "protocol_name" "http" "tcp_check_port" 8545 "server_port" 6000) | indent 6 }}
-{{ include "celo-fullnode.health-checker-server" (dict "protocol_name" "ws" "tcp_check_port" .Values.geth.ws_port "server_port" 6001) | indent 6 }}
-{{ end }}
+        {{- include "common.full-node-container" (dict "Values" $.Values "Release" $.Release "Chart" $.Chart "expose" true "ip_addresses" .Values.geth.public_ip_per_node "syncmode" .Values.geth.syncmode "gcmode" .Values.geth.gcmode "rpc_apis" .Values.geth.rpc_apis "pprof" (or (.Values.metrics) (.Values.pprof.enabled)) "pprof_port" (.Values.pprof.port) "metrics" (or (.Values.metrics) (.Values.metrics)) "ports" .Values.geth.service_node_port_per_full_node "light_serve" .Values.geth.light.serve "light_maxpeers" .Values.geth.light.maxpeers "maxpeers" .Values.geth.maxpeers "geth_flags" (.Values.geth.flags | default "") "extra_setup" (include "celo-fullnode.extra_setup" .)) | nindent 8 }}
+        {{- if .Values.geth.create_network_endpoint_group }}
+        {{- include "celo-fullnode.health-checker-server" (dict "protocol_name" "http" "tcp_check_port" 8545 "server_port" 6000) | nindent 8 }}
+        {{- include "celo-fullnode.health-checker-server" (dict "protocol_name" "ws" "tcp_check_port" .Values.geth.ws_port "server_port" 6001) | nindent 8 }}
+        {{- end }}
       terminationGracePeriodSeconds: {{ .Values.geth.terminationGracePeriodSeconds | default 300 }}
       volumes:
       - name: data

--- a/charts/celo-fullnode/values.yaml
+++ b/charts/celo-fullnode/values.yaml
@@ -58,12 +58,10 @@ storage:
     # resize.topolvm.io/inodes-threshold: 90%
   # -- Size of the persistent volume claim for the celo-blockchain statefulset
   size: 20Gi
-  snapshot:
-    # -- Enable the use of a snapshot as a source for the celo-blockchain statefulset. Snapshot resource must exist in the same namepace
-    enabled: false
-    # -- Class for the snapshot
+  # -- Include a dataSource in the volumeClaimTemplates
+  dataSource:
+    apiGroup: snapshot.storage.k8s.io
     kind: VolumeSnapshot
-    # -- Name of the snapshot (must exist in the same namespace)
     name: forno-snapshot
 
 geth:
@@ -131,6 +129,20 @@ geth:
     serve: 70
   # -- WS-RPC server listening port
   ws_port: 8546
+  # -- Pod Affinity
+  ## see https://www.verygoodsecurity.com/blog/posts/kubernetes-multi-az-deployments-using-pod-anti-affinity
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+            - key: component
+              operator: In
+              values:
+              - celo-fullnode
+          topologyKey: failure-domain.beta.kubernetes.io/zone
+        weight: 100
   # -- HPA configuration for celo-blockchain statefulset. Check official documentation for more info
   autoscaling:
     # -- Enable HPA for celo-blockchain statefulset


### PR DESCRIPTION
Updated celo-fullnode:
- Format/output cleaned
- New common dependency
- Simplified chart using `{{- with .Values...` where possible
- `.Values.storage.snapshot` logic migrated to `.Values.storage.dataSource` to make it analogue to what PVC is expecting (simpler, and can handle more configurations)
- affinity exposed as a Value
- if autoscaling is enabled, the `replicaCount` for generating the services used is the maxReplicas in the hpa.
- Not setting `replicas` in sts when hpa is enabled