### PR TITLE
Set defaults for block catchup fetcher.

### DIFF
--- a/charts/blockscout/Chart.yaml
+++ b/charts/blockscout/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: blockscout
-version: 1.3.8
+version: 1.3.9
 appVersion: v2.0.4-beta
 description: Chart which is used to deploy Blockscout for Celo Networks
 home: https://explorer.celo.org

--- a/charts/blockscout/README.md
+++ b/charts/blockscout/README.md
@@ -2,7 +2,7 @@
 
 Chart which is used to deploy Blockscout for Celo Networks
 
-![Version: 1.3.8](https://img.shields.io/badge/Version-1.3.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.0.4-beta](https://img.shields.io/badge/AppVersion-v2.0.4--beta-informational?style=flat-square)
+![Version: 1.3.9](https://img.shields.io/badge/Version-1.3.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.0.4-beta](https://img.shields.io/badge/AppVersion-v2.0.4--beta-informational?style=flat-square)
 
 - [blockscout](#blockscout)
   - [Chart requirements](#chart-requirements)
@@ -36,7 +36,7 @@ To install/manage a release named `celo-mainnet-fullnode` connected to `mainnet`
 
 ```bash
 # Select the chart release to use
-CHART_RELEASE="oci://us-west1-docker.pkg.dev/celo-testnet/clabs-public-oci/blockscout --version=1.3.8" # Use remote chart and specific version
+CHART_RELEASE="oci://us-west1-docker.pkg.dev/celo-testnet/clabs-public-oci/blockscout --version=1.3.9" # Use remote chart and specific version
 CHART_RELEASE="./" # Use this local folder
 
 # (Only for local chart) Sync helm dependencies
@@ -90,14 +90,15 @@ helm upgrade my-blockscout -f values-alfajores-blockscout2.yaml --namespace=celo
 | blockscout.eventStream.replicas | int | `0` | replicas for eventStream deployment |
 | blockscout.eventStream.resources | object | `{"requests":{"cpu":2,"memory":"1000Mi"}}` | resources for eventStream container |
 | blockscout.eventStream.strategy | object | `{"rollingUpdate":{"maxSurge":1,"maxUnavailable":0}}` | UpdateStrategy for eventStream deployment |
-| blockscout.indexer | object | `{"affinity":{},"db":{"connectionName":"project:region:db-name","name":"blockscout","port":5432,"proxy":{"resources":{"requests":{"cpu":"100m","memory":"40Mi"}}}},"fetchers":{"blockRewards":{"enabled":false}},"livenessProbe":{},"nodeSelector":{},"poolSize":200,"poolSizeReplica":5,"port":4001,"primaryRpcRegion":"indexer","readinessProbe":{"failureThreshold":5,"httpGet":{"path":"/health/readiness","port":"health","scheme":"HTTP"},"initialDelaySeconds":30,"periodSeconds":5,"successThreshold":1,"timeoutSeconds":5},"resources":{"requests":{"cpu":2,"memory":"2G"}},"rpcRegion":"indexer","strategy":{"rollingUpdate":{"maxSurge":1,"maxUnavailable":0}},"terminationGracePeriodSeconds":60,"tracerImplementation":"call_tracer"}` | Configuraton for the indexer component |
+| blockscout.indexer | object | `{"affinity":{},"db":{"connectionName":"project:region:db-name","name":"blockscout","port":5432,"proxy":{"resources":{"requests":{"cpu":"100m","memory":"40Mi"}}}},"fetchers":{"blockRewards":{"enabled":false},"catchup":{"batchSize":5,"concurrency":5}},"livenessProbe":{},"nodeSelector":{},"poolSize":200,"poolSizeReplica":5,"port":4001,"primaryRpcRegion":"indexer","readinessProbe":{"failureThreshold":5,"httpGet":{"path":"/health/readiness","port":"health","scheme":"HTTP"},"initialDelaySeconds":30,"periodSeconds":5,"successThreshold":1,"timeoutSeconds":5},"resources":{"requests":{"cpu":2,"memory":"2G"}},"rpcRegion":"indexer","strategy":{"rollingUpdate":{"maxSurge":1,"maxUnavailable":0}},"terminationGracePeriodSeconds":60,"tracerImplementation":"call_tracer"}` | Configuraton for the indexer component |
 | blockscout.indexer.affinity | object | `{}` | affinity for indexer pods |
 | blockscout.indexer.db | object | `{"connectionName":"project:region:db-name","name":"blockscout","port":5432,"proxy":{"resources":{"requests":{"cpu":"100m","memory":"40Mi"}}}}` | Database configuration for indexer. Prepared to be used with CloudSQL |
 | blockscout.indexer.db.connectionName | string | `"project:region:db-name"` | Name of the CloudSQL connection to use |
 | blockscout.indexer.db.name | string | `"blockscout"` | Name of the database to use. Database is created if it does not exist |
 | blockscout.indexer.db.proxy | object | `{"resources":{"requests":{"cpu":"100m","memory":"40Mi"}}}` | Configuration for the CloudSQL proxy (https://cloud.google.com/sql/docs/mysql/sql-proxy) |
 | blockscout.indexer.db.proxy.resources | object | `{"requests":{"cpu":"100m","memory":"40Mi"}}` | resources for cloud-sql container |
-| blockscout.indexer.fetchers | object | `{"blockRewards":{"enabled":false}}` | Enable CELO blockRewards functionality |
+| blockscout.indexer.fetchers.blockRewards | object | `{"enabled":false}` | Enable CELO blockRewards functionality |
+| blockscout.indexer.fetchers.catchup | object | `{"batchSize":5,"concurrency":5}` | Block catchup fetcher config |
 | blockscout.indexer.livenessProbe | object | `{}` | livenessProbe for indexer container |
 | blockscout.indexer.nodeSelector | object | `{}` | nodeSelector for indexer pods |
 | blockscout.indexer.poolSize | int | `200` | Max number of DB connections excluding read-only API endpoints requests |

--- a/charts/blockscout/templates/blockscout-indexer.deployment.yaml
+++ b/charts/blockscout/templates/blockscout-indexer.deployment.yaml
@@ -94,8 +94,10 @@ spec:
           value: {{ .Values.blockscout.indexer.primaryRpcRegion | quote }}
         - name: INDEXER_DISABLE_BLOCK_REWARD_FETCHER
           value: {{ not .Values.blockscout.indexer.fetchers.blockRewards.enabled | quote }}
-        - name: INDEXER_INTERNAL_TRANSACTIONS_TRACER_TYPE
-          value: {{ .Values.blockscout.indexer.tracerImplementation | quote }}
+        - name: INDEXER_CATCHUP_BLOCKS_BATCH_SIZE
+          value: {{ .Values.blockscout.indexer.fetchers.catchup.batchSize | quote }}
+        - name: INDEXER_CATCHUP_BLOCKS_CONCURRENCY
+          value: {{ .Values.blockscout.indexer.fetchers.catchup.concurrency | quote }}
         {{- include "celo.blockscout.env-vars" $data | nindent 8 }}
       volumes:
         {{- include "celo.blockscout.volume.temporary-dir" . | nindent 8 }}

--- a/charts/blockscout/values.yaml
+++ b/charts/blockscout/values.yaml
@@ -115,8 +115,12 @@ blockscout:
     primaryRpcRegion: "indexer"
     # -- tracer to use to fetch internal transactions - 'js' or 'call_tracer'
     tracerImplementation: "call_tracer"
-    # -- Enable CELO blockRewards functionality
     fetchers:
+      # -- Block catchup fetcher config
+      catchup:
+        batchSize: 5
+        concurrency: 5
+      # -- Enable CELO blockRewards functionality
       blockRewards:
         enabled: false
 


### PR DESCRIPTION
# Description

Sets the default block catchup fetcher params to `[batch_size: 5, concurrency: 5]`. 
Previously both of these values were at 10 which caused timeouts and unretrievable responses when querying archive nodes.

# Testing

* Was running on rc13 for most of yesterday, and resulted in a dramatic increase in block freshness

![image](https://github.com/celo-org/charts/assets/85586/cda1f60d-2004-428f-9c4b-c43337168380)
