### PR TITLE
fix: settings shouldn't be set in light mode

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: common
-version: 0.4.0
+version: 0.4.1
 type: library
 home: https://celo.org
 icon: https://pbs.twimg.com/profile_images/1613170131491848195/InjXBNx9_400x400.jpg

--- a/charts/common/templates/_helpers.tpl
+++ b/charts/common/templates/_helpers.tpl
@@ -208,8 +208,11 @@ fi
       {{- if not (has .Values.genesis.network $mainnet_envs) }}
       $BOOTNODE_FLAG \
       {{- end }}
+      {{- $lightmodes := list "lightest" "light" -}}
+      {{- if not (has .Values.geth.syncmode $lightmodes) }}
       --light.serve={{ if kindIs "invalid" .light_serve }}90{{ else }}{{ .light_serve }}{{ end }} \
       --light.maxpeers={{ if kindIs "invalid" .light_maxpeers }}1000{{ else }}{{ .light_maxpeers }}{{ end }} \
+      {{- end }}
       --maxpeers={{ if kindIs "invalid" .maxpeers }}1200{{ else }}{{ .maxpeers }}{{ end }} \
       --nousb \
       --syncmode={{ .syncmode | default .Values.geth.syncmode }} \


### PR DESCRIPTION
The `celo-fullnode` chart should be able to support light/lightest sync modes according to the settings, but in practice it doesn't because setting the `light.serve` cli argument causes geth to error during start when syncmode isn't full.
This change skips those arguments in those cases. 