### PR TITLE
Update `common` dependency in `celo-fullnode`

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,4 +44,3 @@ This repo uses GitHub Actions to automatically perform the following:
 The [chart-testing Action](https://github.com/helm/chart-testing-action) allows testing the installation/deletion of a chart using a custom `values.yaml` file. In order to do that, the action allows for a chart to have multiple custom values files matching the glob pattern `*-values.yaml` in a directory named `ci` in the root of the chart's directory. The chart is installed and tested for each of these files.
 
 If no custom values file is present, the chart is installed and tested with defaults.
-

--- a/charts/celo-fullnode/Chart.yaml
+++ b/charts/celo-fullnode/Chart.yaml
@@ -19,11 +19,11 @@ keywords:
   - Validator
   - Ethereum
   - Proof-of-Stake
-version: 0.6.1
+version: 0.6.2
 dependencies:
   - name: common
     repository: oci://us-west1-docker.pkg.dev/devopsre/clabs-public-oci
-    version: 0.4.0
+    version: 0.4.1
 maintainers:
   - name: cLabs
     email: devops@clabs.co

--- a/charts/celo-fullnode/README.md
+++ b/charts/celo-fullnode/README.md
@@ -2,7 +2,7 @@
 
 Helm chart for deploying a Celo fullnode. More info at https://docs.celo.org
 
-![Version: 0.6.1](https://img.shields.io/badge/Version-0.6.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.6.0](https://img.shields.io/badge/AppVersion-1.6.0-informational?style=flat-square)
+![Version: 0.6.2](https://img.shields.io/badge/Version-0.6.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.6.0](https://img.shields.io/badge/AppVersion-1.6.0-informational?style=flat-square)
 
 - [celo-fullnode](#celo-fullnode)
   - [Chart requirements](#chart-requirements)
@@ -34,7 +34,7 @@ To install/manage a release named `celo-mainnet-fullnode` connected to `mainnet`
 
 ```bash
 # Select the chart release to use
-CHART_RELEASE="oci://us-west1-docker.pkg.dev/celo-testnet/clabs-public-oci/celo-fullnode --version=0.6.1" # Use remote chart and specific version
+CHART_RELEASE="oci://us-west1-docker.pkg.dev/celo-testnet/clabs-public-oci/celo-fullnode --version=0.6.2" # Use remote chart and specific version
 CHART_RELEASE="./" # Use this local folder
 
 # (Only for local chart) Sync helm dependencies


### PR DESCRIPTION
Update chart dependency version with the updates in #138 in order to be able to deploy in `light` and `lightest` mode.

⚠️ CI will fail until #138 is published.