### PR TITLE
Webhook execution order changes and notes

### DIFF
--- a/charts/image-annotator-webhook/Chart.yaml
+++ b/charts/image-annotator-webhook/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: image-annotator-webhook
 type: application
 icon: https://pbs.twimg.com/profile_images/1613170131491848195/InjXBNx9_400x400.jpg
-version: 0.2.0
+version: 0.3.0
 description: Deploys a kubernetes webhook to mutate podSpecs to include container images as annotations
 keywords:
   - Celo

--- a/charts/image-annotator-webhook/README.md
+++ b/charts/image-annotator-webhook/README.md
@@ -19,7 +19,7 @@ Deploys a kubernetes webhook to mutate podSpecs to include container images as a
 | fullnameOverride | string | `""` | Chart full name override. Please take into account that webhook order execution is based on alphabetical order |
 | image.pullPolicy | string | `"Always"` | Image pullpolicy |
 | image.repository | string | `"us-west1-docker.pkg.dev/devopsre/image-annotator-webhook/image-annotator-webhook"` | Image repository |
-| image.tag | string | `"9f2396fedb94de948a2ebb21ce493ee33691f887"` | Image tag Overrides the image tag whose default is the chart appVersion. |
+| image.tag | string | `"4ca7bd14b0bd17a224006b85e1d9c5c05189a6ed"` | Image tag Overrides the image tag whose default is the chart appVersion. |
 | imagePullSecrets | list | `[]` | Image pull secrets |
 | livenessProbe | object | `{}` | Liveness probe configuration |
 | nameOverride | string | `""` | Chart name override |

--- a/charts/image-annotator-webhook/README.md
+++ b/charts/image-annotator-webhook/README.md
@@ -1,6 +1,6 @@
 # image-annotator-webhook
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 Deploys a kubernetes webhook to mutate podSpecs to include container images as annotations
 
@@ -16,7 +16,7 @@ Deploys a kubernetes webhook to mutate podSpecs to include container images as a
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Kubernetes pod affinity |
 | env.log_level | string | `"debug"` | Env. Var LOG_LEVEL |
-| fullnameOverride | string | `""` | Chart full name override |
+| fullnameOverride | string | `""` | Chart full name override. Please take into account that webhook order execution is based on alphabetical order |
 | image.pullPolicy | string | `"Always"` | Image pullpolicy |
 | image.repository | string | `"us-west1-docker.pkg.dev/devopsre/image-annotator-webhook/image-annotator-webhook"` | Image repository |
 | image.tag | string | `"9f2396fedb94de948a2ebb21ce493ee33691f887"` | Image tag Overrides the image tag whose default is the chart appVersion. |

--- a/charts/image-annotator-webhook/templates/NOTES.txt
+++ b/charts/image-annotator-webhook/templates/NOTES.txt
@@ -1,0 +1,17 @@
+Thank you for installing {{ .Chart.Name }}.
+
+Your release is named {{ .Release.Name }}.
+
+To learn more about the release, try:
+
+  $ helm status {{ .Release.Name }}
+  $ helm get all {{ .Release.Name }}
+
+Please take into account that webhook execution order is done alphabetically.
+If there is any other webhook that modifies the images executed (i.e.: `policy.sigstore.dev`),
+you may need/want the name of the webhook (i.e.: `.Values.fullnameOverride`) is first 
+based on alphabetical order.
+
+To check the existing webhooks of your cluster:
+
+  $ kubectl get mutatingwebhookconfigurations.admissionregistration.k8s.io

--- a/charts/image-annotator-webhook/templates/webhook.yaml
+++ b/charts/image-annotator-webhook/templates/webhook.yaml
@@ -21,9 +21,7 @@ items:
 - apiVersion: admissionregistration.k8s.io/v1
   kind: MutatingWebhookConfiguration
   metadata:
-    # Adding aa to force be first webhook alphabetically.
-    # Reason is to priorize this webhook over policy controller's
-    name: aa{{ template "image-annotator-webhook.fullname" . }}
+    name: {{ template "image-annotator-webhook.fullname" . }}
   webhooks:
   - name: pods.{{ template "image-annotator-webhook.name" . }}.admission
     admissionReviewVersions:

--- a/charts/image-annotator-webhook/templates/webhook.yaml
+++ b/charts/image-annotator-webhook/templates/webhook.yaml
@@ -50,7 +50,7 @@ items:
         operator: DoesNotExist
       - key: image-annotator-webhook/exclude
         operator: DoesNotExist
-    reinvocationPolicy: IfNeeded
+    reinvocationPolicy: Never
     rules:
     - apiGroups:
       - ""

--- a/charts/image-annotator-webhook/values.yaml
+++ b/charts/image-annotator-webhook/values.yaml
@@ -14,7 +14,7 @@ image:
   pullPolicy: Always
   # -- Image tag
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "9f2396fedb94de948a2ebb21ce493ee33691f887"
+  tag: "4ca7bd14b0bd17a224006b85e1d9c5c05189a6ed"
 
 # -- Image pull secrets
 imagePullSecrets: []

--- a/charts/image-annotator-webhook/values.yaml
+++ b/charts/image-annotator-webhook/values.yaml
@@ -1,7 +1,7 @@
 ---
 # -- Chart name override
 nameOverride: ""
-# -- Chart full name override
+# -- Chart full name override. Please take into account that webhook order execution is based on alphabetical order
 fullnameOverride: ""
 
 # -- Number of deployment replicas


### PR DESCRIPTION
It is important that image-annotator-webhook is executed previous to policy controller webhook.
With default values, the webhook names will be `image-annotator-webhook` and `policy.sigstore.dev` so we're good.

Also webhook can be invoked multiple times for the same resource, so the webhook (in this case image-annotator-webhook) must have sanity checks to avoid replacing the annotation with tags by the image with digest (if not, it'd be useless). This is is handled in https://github.com/celo-org/image-annotator-webhook