### PR TITLE
Update the default image-annotator

### DIFF
--- a/charts/image-annotator-webhook/Chart.yaml
+++ b/charts/image-annotator-webhook/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: image-annotator-webhook
 type: application
 icon: https://pbs.twimg.com/profile_images/1613170131491848195/InjXBNx9_400x400.jpg
-version: 0.3.3
+version: 0.3.4
 description: Deploys a kubernetes webhook to mutate podSpecs to include container images as annotations
 keywords:
   - Celo

--- a/charts/image-annotator-webhook/README.md
+++ b/charts/image-annotator-webhook/README.md
@@ -1,6 +1,6 @@
 # image-annotator-webhook
 
-![Version: 0.3.3](https://img.shields.io/badge/Version-0.3.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.3.4](https://img.shields.io/badge/Version-0.3.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 Deploys a kubernetes webhook to mutate podSpecs to include container images as annotations
 
@@ -19,7 +19,7 @@ Deploys a kubernetes webhook to mutate podSpecs to include container images as a
 | fullnameOverride | string | `""` | Chart full name override. Please take into account that webhook order execution is based on alphabetical order |
 | image.pullPolicy | string | `"Always"` | Image pullpolicy |
 | image.repository | string | `"us-west1-docker.pkg.dev/devopsre/image-annotator-webhook/image-annotator-webhook"` | Image repository |
-| image.tag | string | `"6505a2a84d56779d092331cbbdb9588b0ed165bb"` | Image tag Overrides the image tag whose default is the chart appVersion. |
+| image.tag | string | `"4c0b713275ec497e973733f9e91c6a791e23890b"` | Image tag Overrides the image tag whose default is the chart appVersion. |
 | imagePullSecrets | list | `[]` | Image pull secrets |
 | livenessProbe | object | `{}` | Liveness probe configuration |
 | nameOverride | string | `""` | Chart name override |

--- a/charts/image-annotator-webhook/values.yaml
+++ b/charts/image-annotator-webhook/values.yaml
@@ -14,7 +14,7 @@ image:
   pullPolicy: Always
   # -- Image tag
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "6505a2a84d56779d092331cbbdb9588b0ed165bb"
+  tag: "4c0b713275ec497e973733f9e91c6a791e23890b"
 
 # -- Image pull secrets
 imagePullSecrets: []


### PR DESCRIPTION
Update the image-annotator with latest main commit. The new commits fixes a bug that caused that sometimes the final annotation added was with image hash (instead of tag)