### PR TITLE
Added dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      day: "monday"
+      time: "09:30"
+      timezone: "Europe/Berlin"
+      interval: "weekly"


### PR DESCRIPTION
Added dependabot.yml config for github-actions.

[Helm charts dependencies are not supported](https://github.com/dependabot/dependabot-core/issues/2237).