### PR TITLE
Update common package for testnet update

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: common
-version: 0.4.3
+version: 0.5.0
 type: library
 home: https://celo.org
 icon: https://pbs.twimg.com/profile_images/1613170131491848195/InjXBNx9_400x400.jpg

--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -2,7 +2,7 @@
 
 Helm chart with helper templates and functions for Celo nodes. Import into your chart with `dependencies` and use the templates and functions
 
-![Version: 0.4.3](https://img.shields.io/badge/Version-0.4.3-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
 
 - [common](#common)
   - [Chart releases](#chart-releases)
@@ -23,7 +23,7 @@ To import this chart into your chart, add the following to your `requirements.ya
 dependencies:
   - name: common
     repository: oci://us-west1-docker.pkg.dev/celo-testnet/clabs-public-oci
-    version: 0.4.3
+    version: 0.5.0
 ```
 
 ## Values


### PR DESCRIPTION
Changes required for the incoming `testnet` package upgrade.

- Fixes when `namespace` has `-` in the name
- Fixes/Improve when `testnet` package does not have `bootnode` enabled nor a bootnode Ip set (required if using `testnet` for mainnet/alfajores/baklava without a bootnode)

Bumped version to `0.5.0` to be aligned with incoming `testnet` package version.