### PR TITLE
Blockscout: Exit early if secrets-init process fails

### DIFF
--- a/charts/blockscout/Chart.yaml
+++ b/charts/blockscout/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: blockscout
-version: 1.3.13
+version: 1.3.14
 appVersion: v2.0.4-beta
 description: Chart which is used to deploy Blockscout for Celo Networks
 home: https://explorer.celo.org

--- a/charts/blockscout/README.md
+++ b/charts/blockscout/README.md
@@ -2,7 +2,7 @@
 
 Chart which is used to deploy Blockscout for Celo Networks
 
-![Version: 1.3.13](https://img.shields.io/badge/Version-1.3.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.0.4-beta](https://img.shields.io/badge/AppVersion-v2.0.4--beta-informational?style=flat-square)
+![Version: 1.3.14](https://img.shields.io/badge/Version-1.3.14-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.0.4-beta](https://img.shields.io/badge/AppVersion-v2.0.4--beta-informational?style=flat-square)
 
 - [blockscout](#blockscout)
   - [Chart requirements](#chart-requirements)
@@ -36,7 +36,7 @@ To install/manage a release named `celo-mainnet-fullnode` connected to `mainnet`
 
 ```bash
 # Select the chart release to use
-CHART_RELEASE="oci://us-west1-docker.pkg.dev/celo-testnet/clabs-public-oci/blockscout --version=1.3.13" # Use remote chart and specific version
+CHART_RELEASE="oci://us-west1-docker.pkg.dev/celo-testnet/clabs-public-oci/blockscout --version=1.3.14" # Use remote chart and specific version
 CHART_RELEASE="./" # Use this local folder
 
 # (Only for local chart) Sync helm dependencies
@@ -148,7 +148,7 @@ helm upgrade my-blockscout -f values-alfajores-blockscout2.yaml --namespace=celo
 | blockscout.web.strategy | object | `{"rollingUpdate":{"maxSurge":1,"maxUnavailable":"20%"}}` | UpdateStrategy for web deployment |
 | blockscout.web.tokenIcons | object | `{"enabled":false}` | Show token icons |
 | changeCause | string | `""` | Add annotation with a message about the upgrade process trigger. Intended to be used by CD or deployment tool |
-| infrastructure | object | `{"affinity":{},"database":{"connectionName":"project:region:db-name","enableCloudSQLProxy":true,"name":"blockscout","port":5432,"proxy":{"host":"127.0.0.1","livenessProbe":{},"port":5432,"readinessProbe":{},"resources":{"requests":{"cpu":"10m","memory":"20Mi"}}}},"domainName":"celo-testnet.org","gcp":{"projectId":"celo-testnet-production","serviceAccount":""},"grafanaUrl":"https://clabs.grafana.net","metrics":{"enabled":false},"nodeSelector":{}}` | Infrastructure/Kubernetes shared configuration |
+| infrastructure | object | `{"affinity":{},"database":{"connectionName":"project:region:db-name","enableCloudSQLProxy":true,"name":"blockscout","port":5432,"proxy":{"host":"127.0.0.1","livenessProbe":{},"port":5432,"readinessProbe":{},"resources":{"requests":{"cpu":"10m","memory":"20Mi"}}}},"domainName":"celo-testnet.org","gcp":{"projectId":"celo-testnet-production","serviceAccount":""},"grafanaUrl":"https://clabs.grafana.net","metrics":{"enabled":false},"nodeSelector":{},"secretsInit":{"exitEarly":true}}` | Infrastructure/Kubernetes shared configuration |
 | infrastructure.affinity | object | `{}` | Default affinity for the pods |
 | infrastructure.database.proxy.livenessProbe | object | `{}` | livenessProbe for cloud-sql container |
 | infrastructure.database.proxy.readinessProbe | object | `{}` | livinessProbe for cloud-sql container |
@@ -157,6 +157,8 @@ helm upgrade my-blockscout -f values-alfajores-blockscout2.yaml --namespace=celo
 | infrastructure.grafanaUrl | string | `"https://clabs.grafana.net"` | Grafana url to use during deployment |
 | infrastructure.metrics | object | `{"enabled":false}` | Enable prometheus metrics, using annotations |
 | infrastructure.nodeSelector | object | `{}` | Default nodeSelector for the pods |
+| infrastructure.secretsInit | object | `{"exitEarly":true}` | secrets-init configuration |
+| infrastructure.secretsInit.exitEarly | bool | `true` | exit when a provider fails or a secret is not found |
 | ingressClassName | string | `"nginx"` |  |
 | network | object | `{"name":"Celo","networkID":1101,"nodes":{"archiveNodes":{"jsonrpcHttpUrl":"http://tx-nodes-private:8545","jsonrpcWsUrl":"ws://tx-nodes-private:8545"},"fullNodes":{"jsonrpcPublicHttp":""}}}` | Configuration related with the CELO network |
 | network.nodes | object | `{"archiveNodes":{"jsonrpcHttpUrl":"http://tx-nodes-private:8545","jsonrpcWsUrl":"ws://tx-nodes-private:8545"},"fullNodes":{"jsonrpcPublicHttp":""}}` | RPC/WS endpoints for the node network. Indexer requires archive data |

--- a/charts/blockscout/templates/_helpers.tpl
+++ b/charts/blockscout/templates/_helpers.tpl
@@ -191,7 +191,7 @@ blockscout components.
 {{- define "celo.blockscout.env-vars" -}}
 {{- $user := .Values.blockscout.shared.secrets.dbUser -}}
 {{- $password := .Values.blockscout.shared.secrets.dbPassword -}}
-{{- if .Values.infrastructure.secretsInit.failFast -}}
+{{- if .Values.infrastructure.secretsInit.exitEarly -}}
 - name: EXIT_EARLY
   value: "true"
 {{- end }}

--- a/charts/blockscout/templates/_helpers.tpl
+++ b/charts/blockscout/templates/_helpers.tpl
@@ -191,6 +191,10 @@ blockscout components.
 {{- define "celo.blockscout.env-vars" -}}
 {{- $user := .Values.blockscout.shared.secrets.dbUser -}}
 {{- $password := .Values.blockscout.shared.secrets.dbPassword -}}
+{{- if .Values.infrastructure.secretsInit.failFast -}}
+- name: EXIT_EARLY
+  value: "true"
+{{- end }}
 - name: DATABASE_USER
   value: {{ $user }}
 - name: DATABASE_PASSWORD

--- a/charts/blockscout/values.yaml
+++ b/charts/blockscout/values.yaml
@@ -407,6 +407,10 @@ infrastructure:
   # -- Enable prometheus metrics, using annotations
   metrics:
     enabled: false
+  # -- secrets-init configuration
+  secretsInit:
+    # -- exit when a provider fails or a secret is not found
+    failFast: true
   # -- Default affinity for the pods
   affinity: {}
   # -- Default nodeSelector for the pods

--- a/charts/blockscout/values.yaml
+++ b/charts/blockscout/values.yaml
@@ -410,7 +410,7 @@ infrastructure:
   # -- secrets-init configuration
   secretsInit:
     # -- exit when a provider fails or a secret is not found
-    failFast: true
+    exitEarly: true
   # -- Default affinity for the pods
   affinity: {}
   # -- Default nodeSelector for the pods


### PR DESCRIPTION
Recently secrets-init behavior changed and now it does not restart when the child process fails.

Adding the option to set `EXIT_EARLY` as env var for blockscout containers running using secrets-init, so in case some secrets cannot be recovered, fail the process. Thus, the pod would also fail in this situation and it will be restarted by kubernetes scheduler, which would help for transitory errors.

It may not help if the child process (blockscout) dies for any other reason, but secrets-init remain running and K8s does not consider as unhealthy. This would only affect to indexer pods (web/api are covered by livenessProbe). 
