### PR TITLE
Enable tcpSocket livenessProbe for indexer

### DIFF
--- a/charts/blockscout/Chart.yaml
+++ b/charts/blockscout/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: blockscout
-version: 1.3.14
+version: 1.3.15
 appVersion: v2.0.4-beta
 description: Chart which is used to deploy Blockscout for Celo Networks
 home: https://explorer.celo.org

--- a/charts/blockscout/README.md
+++ b/charts/blockscout/README.md
@@ -2,7 +2,7 @@
 
 Chart which is used to deploy Blockscout for Celo Networks
 
-![Version: 1.3.14](https://img.shields.io/badge/Version-1.3.14-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.0.4-beta](https://img.shields.io/badge/AppVersion-v2.0.4--beta-informational?style=flat-square)
+![Version: 1.3.15](https://img.shields.io/badge/Version-1.3.15-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.0.4-beta](https://img.shields.io/badge/AppVersion-v2.0.4--beta-informational?style=flat-square)
 
 - [blockscout](#blockscout)
   - [Chart requirements](#chart-requirements)
@@ -36,7 +36,7 @@ To install/manage a release named `celo-mainnet-fullnode` connected to `mainnet`
 
 ```bash
 # Select the chart release to use
-CHART_RELEASE="oci://us-west1-docker.pkg.dev/celo-testnet/clabs-public-oci/blockscout --version=1.3.14" # Use remote chart and specific version
+CHART_RELEASE="oci://us-west1-docker.pkg.dev/celo-testnet/clabs-public-oci/blockscout --version=1.3.15" # Use remote chart and specific version
 CHART_RELEASE="./" # Use this local folder
 
 # (Only for local chart) Sync helm dependencies
@@ -60,7 +60,7 @@ helm upgrade my-blockscout -f values-alfajores-blockscout2.yaml --namespace=celo
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| blockscout.api | object | `{"affinity":{},"autoscaling":{"maxReplicas":10,"minReplicas":2,"target":{"cpu":70}},"db":{"connectionName":"project:region:db-name","name":"blockscout","port":5432,"proxy":{"resources":{"requests":{"cpu":"10m","memory":"20Mi"}}}},"hostname":"","livenessProbe":{"failureThreshold":5,"httpGet":{"path":"/api/v1/health/liveness","port":"http","scheme":"HTTP"},"initialDelaySeconds":60,"periodSeconds":5,"successThreshold":1,"timeoutSeconds":5},"nodeSelector":{},"poolSize":30,"poolSizeReplica":5,"port":4000,"primaryRpcRegion":"indexer","rateLimit":"1000000","readinessProbe":{"failureThreshold":5,"httpGet":{"path":"/api/v1/health/liveness","port":"http","scheme":"HTTP"},"initialDelaySeconds":30,"periodSeconds":5,"successThreshold":1,"timeoutSeconds":5},"resources":{"requests":{"cpu":0.5,"memory":"500Mi"}},"rpcRegion":"api","strategy":{"rollingUpdate":{"maxSurge":1,"maxUnavailable":"20%"}},"suffix":{"enabled":false,"path":""}}` | Configuraton for the api component |
+| blockscout.api | object | `{"affinity":{},"autoscaling":{"maxReplicas":10,"minReplicas":2,"target":{"cpu":70}},"db":{"connectionName":"project:region:db-name","name":"blockscout","port":5432,"proxy":{"resources":{"requests":{"cpu":"10m","memory":"20Mi"}}}},"hostname":"","livenessProbe":{"failureThreshold":5,"httpGet":{"path":"/api/v1/health/liveness","port":"http","scheme":"HTTP"},"initialDelaySeconds":60,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":5},"nodeSelector":{},"poolSize":30,"poolSizeReplica":5,"port":4000,"primaryRpcRegion":"indexer","rateLimit":"1000000","readinessProbe":{"failureThreshold":5,"httpGet":{"path":"/api/v1/health/liveness","port":"http","scheme":"HTTP"},"initialDelaySeconds":30,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":5},"resources":{"requests":{"cpu":0.5,"memory":"500Mi"}},"rpcRegion":"api","strategy":{"rollingUpdate":{"maxSurge":1,"maxUnavailable":"20%"}},"suffix":{"enabled":false,"path":""}}` | Configuraton for the api component |
 | blockscout.api.affinity | object | `{}` | affinity for api pods |
 | blockscout.api.autoscaling | object | `{"maxReplicas":10,"minReplicas":2,"target":{"cpu":70}}` | HPA configuration for api deployment |
 | blockscout.api.db | object | `{"connectionName":"project:region:db-name","name":"blockscout","port":5432,"proxy":{"resources":{"requests":{"cpu":"10m","memory":"20Mi"}}}}` | Database configuration for indexer. Prepared to be used with CloudSQL |
@@ -69,13 +69,13 @@ helm upgrade my-blockscout -f values-alfajores-blockscout2.yaml --namespace=celo
 | blockscout.api.db.proxy | object | `{"resources":{"requests":{"cpu":"10m","memory":"20Mi"}}}` | Configuration for the CloudSQL proxy (https://cloud.google.com/sql/docs/mysql/sql-proxy) |
 | blockscout.api.db.proxy.resources | object | `{"requests":{"cpu":"10m","memory":"20Mi"}}` | resources for cloud-sql container |
 | blockscout.api.hostname | string | `""` | Hostname for api ingress endpoint |
-| blockscout.api.livenessProbe | object | `{"failureThreshold":5,"httpGet":{"path":"/api/v1/health/liveness","port":"http","scheme":"HTTP"},"initialDelaySeconds":60,"periodSeconds":5,"successThreshold":1,"timeoutSeconds":5}` | livenessProbe for api container |
+| blockscout.api.livenessProbe | object | `{"failureThreshold":5,"httpGet":{"path":"/api/v1/health/liveness","port":"http","scheme":"HTTP"},"initialDelaySeconds":60,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":5}` | livenessProbe for api container |
 | blockscout.api.nodeSelector | object | `{}` | nodeSelector for api pods |
 | blockscout.api.poolSize | int | `30` | Max number of DB connections excluding read-only API endpoints requests |
 | blockscout.api.poolSizeReplica | int | `5` | Max number of DB connections for read-only API endpoints requests |
 | blockscout.api.primaryRpcRegion | string | `"indexer"` | PRIMARY_REGION env variable for api pod. Do not change. |
 | blockscout.api.rateLimit | string | `"1000000"` | request rateLimit for api coponent |
-| blockscout.api.readinessProbe | object | `{"failureThreshold":5,"httpGet":{"path":"/api/v1/health/liveness","port":"http","scheme":"HTTP"},"initialDelaySeconds":30,"periodSeconds":5,"successThreshold":1,"timeoutSeconds":5}` | readinessProbe for api container |
+| blockscout.api.readinessProbe | object | `{"failureThreshold":5,"httpGet":{"path":"/api/v1/health/liveness","port":"http","scheme":"HTTP"},"initialDelaySeconds":30,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":5}` | readinessProbe for api container |
 | blockscout.api.resources | object | `{"requests":{"cpu":0.5,"memory":"500Mi"}}` | resources for api container |
 | blockscout.api.rpcRegion | string | `"api"` | MY_REGION env variable for api pod. Do not change. |
 | blockscout.api.strategy | object | `{"rollingUpdate":{"maxSurge":1,"maxUnavailable":"20%"}}` | UpdateStrategy for api deployment |
@@ -91,7 +91,7 @@ helm upgrade my-blockscout -f values-alfajores-blockscout2.yaml --namespace=celo
 | blockscout.eventStream.replicas | int | `0` | replicas for eventStream deployment |
 | blockscout.eventStream.resources | object | `{"requests":{"cpu":2,"memory":"1000Mi"}}` | resources for eventStream container |
 | blockscout.eventStream.strategy | object | `{"rollingUpdate":{"maxSurge":1,"maxUnavailable":0}}` | UpdateStrategy for eventStream deployment |
-| blockscout.indexer | object | `{"affinity":{},"db":{"connectionName":"project:region:db-name","name":"blockscout","port":5432,"proxy":{"resources":{"requests":{"cpu":"100m","memory":"40Mi"}}}},"fetchers":{"blockRewards":{"enabled":false},"catchup":{"batchSize":5,"concurrency":5}},"livenessProbe":{},"nodeSelector":{},"poolSize":200,"poolSizeReplica":5,"port":4001,"primaryRpcRegion":"indexer","readinessProbe":{"failureThreshold":5,"httpGet":{"path":"/health/readiness","port":"health","scheme":"HTTP"},"initialDelaySeconds":30,"periodSeconds":5,"successThreshold":1,"timeoutSeconds":5},"resources":{"requests":{"cpu":2,"memory":"2G"}},"rpcRegion":"indexer","strategy":{"rollingUpdate":{"maxSurge":1,"maxUnavailable":0}},"terminationGracePeriodSeconds":60,"tracerImplementation":"call_tracer"}` | Configuraton for the indexer component |
+| blockscout.indexer | object | `{"affinity":{},"db":{"connectionName":"project:region:db-name","name":"blockscout","port":5432,"proxy":{"resources":{"requests":{"cpu":"100m","memory":"40Mi"}}}},"fetchers":{"blockRewards":{"enabled":false},"catchup":{"batchSize":5,"concurrency":5}},"livenessProbe":{"failureThreshold":5,"initialDelaySeconds":60,"periodSeconds":30,"tcpSocket":{"port":"health"}},"nodeSelector":{},"poolSize":200,"poolSizeReplica":5,"port":4001,"primaryRpcRegion":"indexer","readinessProbe":{"failureThreshold":5,"httpGet":{"path":"/health/readiness","port":"health","scheme":"HTTP"},"initialDelaySeconds":30,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":5},"resources":{"requests":{"cpu":2,"memory":"2G"}},"rpcRegion":"indexer","strategy":{"rollingUpdate":{"maxSurge":1,"maxUnavailable":0}},"terminationGracePeriodSeconds":60,"tracerImplementation":"call_tracer"}` | Configuraton for the indexer component |
 | blockscout.indexer.affinity | object | `{}` | affinity for indexer pods |
 | blockscout.indexer.db | object | `{"connectionName":"project:region:db-name","name":"blockscout","port":5432,"proxy":{"resources":{"requests":{"cpu":"100m","memory":"40Mi"}}}}` | Database configuration for indexer. Prepared to be used with CloudSQL |
 | blockscout.indexer.db.connectionName | string | `"project:region:db-name"` | Name of the CloudSQL connection to use |
@@ -100,12 +100,12 @@ helm upgrade my-blockscout -f values-alfajores-blockscout2.yaml --namespace=celo
 | blockscout.indexer.db.proxy.resources | object | `{"requests":{"cpu":"100m","memory":"40Mi"}}` | resources for cloud-sql container |
 | blockscout.indexer.fetchers.blockRewards | object | `{"enabled":false}` | Enable CELO blockRewards functionality |
 | blockscout.indexer.fetchers.catchup | object | `{"batchSize":5,"concurrency":5}` | Block catchup fetcher config |
-| blockscout.indexer.livenessProbe | object | `{}` | livenessProbe for indexer container |
+| blockscout.indexer.livenessProbe | object | `{"failureThreshold":5,"initialDelaySeconds":60,"periodSeconds":30,"tcpSocket":{"port":"health"}}` | livenessProbe for indexer container |
 | blockscout.indexer.nodeSelector | object | `{}` | nodeSelector for indexer pods |
 | blockscout.indexer.poolSize | int | `200` | Max number of DB connections excluding read-only API endpoints requests |
 | blockscout.indexer.poolSizeReplica | int | `5` | Max number of DB connections for read-only API endpoints requests |
 | blockscout.indexer.primaryRpcRegion | string | `"indexer"` | PRIMARY_REGION env variable for indexer pod. Do not change. |
-| blockscout.indexer.readinessProbe | object | `{"failureThreshold":5,"httpGet":{"path":"/health/readiness","port":"health","scheme":"HTTP"},"initialDelaySeconds":30,"periodSeconds":5,"successThreshold":1,"timeoutSeconds":5}` | readinessProbe for indexer container |
+| blockscout.indexer.readinessProbe | object | `{"failureThreshold":5,"httpGet":{"path":"/health/readiness","port":"health","scheme":"HTTP"},"initialDelaySeconds":30,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":5}` | readinessProbe for indexer container |
 | blockscout.indexer.resources | object | `{"requests":{"cpu":2,"memory":"2G"}}` | resources for indexer container |
 | blockscout.indexer.rpcRegion | string | `"indexer"` | MY_REGION env variable for indexer pod. Do not change. |
 | blockscout.indexer.strategy | object | `{"rollingUpdate":{"maxSurge":1,"maxUnavailable":0}}` | UpdateStrategy for indexer deployment |
@@ -121,7 +121,7 @@ helm upgrade my-blockscout -f values-alfajores-blockscout2.yaml --namespace=celo
 | blockscout.shared.image | object | `{"pullPolicy":"Always","repository":"gcr.io/celo-testnet/blockscout","tag":"c6ca0da21bd238948d13ec2fabf4428a9dbbc7b6"}` | Image to use for blockscout components |
 | blockscout.shared.migrationJobInitialValue | string | `"{0,0}"` | Starting point for data migration job (`INITIAL_VALUE` env var) |
 | blockscout.shared.secrets | object | `{"analyticsKey":"","campaignBannerApiUrl":"","dbPassword":"","dbUser":"","discordWebhookUrl":"","erlang_cookie":"","grafanaCloud":"","recaptcha_apiKey":"","recaptcha_projectId":"","recaptcha_secretKey":"","recaptcha_siteKey":"","segmentKey":""}` | Reference to secrets. Format: gcp:secretmanager:projects/<project-id>/secrets/<env>-blockscout-<secret-key>. Using tool https://github.com/doitintl/secrets-init |
-| blockscout.web | object | `{"accountPoolSize":1,"affinity":{},"appsMenu":{"enabled":true},"autoscaling":{"maxReplicas":5,"minReplicas":2,"target":{"cpu":70}},"basicAuth":{"enabled":false},"campaignBanner":{"refreshInterval":"60"},"db":{"connectionName":"project:region:db-name","name":"blockscout","port":5432,"proxy":{"resources":{"requests":{"cpu":"10m","memory":"20Mi"}}}},"envHostname":"","extraEnvironments":{"source":[],"target":[]},"homepage":{"showPrice":true,"showTxs":false},"hostname":"","liveUpdates":{"disabled":true},"livenessProbe":{"failureThreshold":5,"httpGet":{"path":"/api/v1/health/liveness","port":"http","scheme":"HTTP"},"initialDelaySeconds":60,"periodSeconds":5,"successThreshold":1,"timeoutSeconds":5},"nodeSelector":{},"poolSize":30,"poolSizeReplica":5,"port":4000,"primaryRpcRegion":"indexer","readinessProbe":{"failureThreshold":5,"httpGet":{"path":"/api/v1/health/liveness","port":"http","scheme":"HTTP"},"initialDelaySeconds":30,"periodSeconds":5,"successThreshold":1,"timeoutSeconds":5},"resources":{"requests":{"cpu":"500m","memory":"250M"}},"rpcRegion":"web","sourcify":{"enabled":true,"repoUrl":"https://repo.sourcify.dev/contracts","serverUrl":"https://sourcify.dev/server"},"stats":{"enabled":false,"makerdojo":"","reportUrl":""},"strategy":{"rollingUpdate":{"maxSurge":1,"maxUnavailable":"20%"}},"suffix":{"enabled":false,"path":""},"tokenIcons":{"enabled":false}}` | Configuraton for the web component |
+| blockscout.web | object | `{"accountPoolSize":1,"affinity":{},"appsMenu":{"enabled":true},"autoscaling":{"maxReplicas":5,"minReplicas":2,"target":{"cpu":70}},"basicAuth":{"enabled":false},"campaignBanner":{"refreshInterval":"60"},"db":{"connectionName":"project:region:db-name","name":"blockscout","port":5432,"proxy":{"resources":{"requests":{"cpu":"10m","memory":"20Mi"}}}},"envHostname":"","extraEnvironments":{"source":[],"target":[]},"homepage":{"showPrice":true,"showTxs":false},"hostname":"","liveUpdates":{"disabled":true},"livenessProbe":{"failureThreshold":5,"httpGet":{"path":"/api/v1/health/liveness","port":"http","scheme":"HTTP"},"initialDelaySeconds":60,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":5},"nodeSelector":{},"poolSize":30,"poolSizeReplica":5,"port":4000,"primaryRpcRegion":"indexer","readinessProbe":{"failureThreshold":5,"httpGet":{"path":"/api/v1/health/liveness","port":"http","scheme":"HTTP"},"initialDelaySeconds":30,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":5},"resources":{"requests":{"cpu":"500m","memory":"250M"}},"rpcRegion":"web","sourcify":{"enabled":true,"repoUrl":"https://repo.sourcify.dev/contracts","serverUrl":"https://sourcify.dev/server"},"stats":{"enabled":false,"makerdojo":"","reportUrl":""},"strategy":{"rollingUpdate":{"maxSurge":1,"maxUnavailable":"20%"}},"suffix":{"enabled":false,"path":""},"tokenIcons":{"enabled":false}}` | Configuraton for the web component |
 | blockscout.web.accountPoolSize | int | `1` | ACCOUNT_POOL_SIZE env variable for web pod |
 | blockscout.web.affinity | object | `{}` | affinity for web pods |
 | blockscout.web.appsMenu | object | `{"enabled":true}` | Configuration for the app menu on the web, for customizing the list of apps on `More` menu |
@@ -137,12 +137,12 @@ helm upgrade my-blockscout -f values-alfajores-blockscout2.yaml --namespace=celo
 | blockscout.web.homepage.showTxs | bool | `false` | Show the tx chart on the homepage |
 | blockscout.web.hostname | string | `""` | Hostname for web ingress endpoint (also applies to api at /(graphql|graphiql|api)). If empty, will be generated based on release name and domainName. |
 | blockscout.web.liveUpdates | object | `{"disabled":true}` | DISABLE_LIVE_UPDATES env variable for web pod |
-| blockscout.web.livenessProbe | object | `{"failureThreshold":5,"httpGet":{"path":"/api/v1/health/liveness","port":"http","scheme":"HTTP"},"initialDelaySeconds":60,"periodSeconds":5,"successThreshold":1,"timeoutSeconds":5}` | livenessProbe for Web container |
+| blockscout.web.livenessProbe | object | `{"failureThreshold":5,"httpGet":{"path":"/api/v1/health/liveness","port":"http","scheme":"HTTP"},"initialDelaySeconds":60,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":5}` | livenessProbe for Web container |
 | blockscout.web.nodeSelector | object | `{}` | nodeSelector for web pods |
 | blockscout.web.poolSize | int | `30` | Max number of DB connections excluding read-only API endpoints requests |
 | blockscout.web.poolSizeReplica | int | `5` | Max number of DB connections for read-only API endpoints requests |
 | blockscout.web.primaryRpcRegion | string | `"indexer"` | PRIMARY_REGION env variable for web pod. Do not change. |
-| blockscout.web.readinessProbe | object | `{"failureThreshold":5,"httpGet":{"path":"/api/v1/health/liveness","port":"http","scheme":"HTTP"},"initialDelaySeconds":30,"periodSeconds":5,"successThreshold":1,"timeoutSeconds":5}` | readinessProbe for web container |
+| blockscout.web.readinessProbe | object | `{"failureThreshold":5,"httpGet":{"path":"/api/v1/health/liveness","port":"http","scheme":"HTTP"},"initialDelaySeconds":30,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":5}` | readinessProbe for web container |
 | blockscout.web.resources | object | `{"requests":{"cpu":"500m","memory":"250M"}}` | resources for web container |
 | blockscout.web.rpcRegion | string | `"web"` | MY_REGION env variable for web pod. Do not change. |
 | blockscout.web.strategy | object | `{"rollingUpdate":{"maxSurge":1,"maxUnavailable":"20%"}}` | UpdateStrategy for web deployment |

--- a/charts/blockscout/values.yaml
+++ b/charts/blockscout/values.yaml
@@ -85,21 +85,16 @@ blockscout:
         port: health
         scheme: HTTP
       initialDelaySeconds: 30
-      periodSeconds: 5
+      periodSeconds: 10
       successThreshold: 1
       timeoutSeconds: 5
     # -- livenessProbe for indexer container
-    livenessProbe: {}
-    # livenessProbe:
-    #   failureThreshold: 5
-    #   httpGet:
-    #     path: /health/liveness
-    #     port: health
-    #     scheme: HTTP
-    #   initialDelaySeconds: 30
-    #   periodSeconds: 5
-    #   successThreshold: 1
-    #   timeoutSeconds: 5
+    livenessProbe:
+      failureThreshold: 5
+      tcpSocket:
+        port: health
+      initialDelaySeconds: 60
+      periodSeconds: 30
     # -- resources for indexer container
     resources:
       requests:
@@ -179,7 +174,7 @@ blockscout:
         port: http
         scheme: HTTP
       initialDelaySeconds: 30
-      periodSeconds: 5
+      periodSeconds: 10
       successThreshold: 1
       timeoutSeconds: 5
     # -- livenessProbe for api container
@@ -190,7 +185,7 @@ blockscout:
         port: http
         scheme: HTTP
       initialDelaySeconds: 60
-      periodSeconds: 5
+      periodSeconds: 10
       successThreshold: 1
       timeoutSeconds: 5
     # -- resources for api container
@@ -267,7 +262,7 @@ blockscout:
         port: http
         scheme: HTTP
       initialDelaySeconds: 30
-      periodSeconds: 5
+      periodSeconds: 10
       successThreshold: 1
       timeoutSeconds: 5
     # -- livenessProbe for Web container
@@ -278,7 +273,7 @@ blockscout:
         port: http
         scheme: HTTP
       initialDelaySeconds: 60
-      periodSeconds: 5
+      periodSeconds: 10
       successThreshold: 1
       timeoutSeconds: 5
     sourcify:


### PR DESCRIPTION
Add a default `livenessProbe` in indexer pod that checks that `health` port is listening (as more basic check done to confirm blockscout process is running).