### PR TITLE
Removes DevTools as code owner from Blockscout and Celo Safe

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,14 +2,3 @@
 # the repo. Unless a later match takes precedence,
 # they will be requested for review when someone opens a pull request.
 * @celo-org/devopsre
-
-# Helm Charts for the Celo Safe service.
-# See the following for the application code:
-#   - https://github.com/celo-org/safe-client-gateway
-#   - https://github.com/celo-org/safe-config-service
-#   - https://github.com/celo-org/safe-transaction-service
-/charts/safe-client-gateway/ @celo-org/devopsre
-/charts/safe-config-service/ @celo-org/devopsre
-/charts/safe-transaction-service/ @celo-org/devopsre 
-
-/charts/blockscout/ @celo-org/devopsre 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,4 +12,4 @@
 /charts/safe-config-service/ @celo-org/devtooling @celo-org/devopsre
 /charts/safe-transaction-service/ @celo-org/devtooling @celo-org/devopsre 
 
-/charts/blockscout/ @celo-org/devtooling @celo-org/devopsre 
+/charts/blockscout/ @celo-org/devopsre 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,8 +8,8 @@
 #   - https://github.com/celo-org/safe-client-gateway
 #   - https://github.com/celo-org/safe-config-service
 #   - https://github.com/celo-org/safe-transaction-service
-/charts/safe-client-gateway/ @celo-org/devtooling @celo-org/devopsre
-/charts/safe-config-service/ @celo-org/devtooling @celo-org/devopsre
-/charts/safe-transaction-service/ @celo-org/devtooling @celo-org/devopsre 
+/charts/safe-client-gateway/ @celo-org/devopsre
+/charts/safe-config-service/ @celo-org/devopsre
+/charts/safe-transaction-service/ @celo-org/devopsre 
 
 /charts/blockscout/ @celo-org/devopsre 


### PR DESCRIPTION
In practice, the DevTooling team never reviews Helm chart and Kubernetes related PRs. But being a default code owner clutters our GitHub notifications.

I propose removing our team, and leaving devopsre as the sole default code owner. 
DevTooling can always be marked as reviewer manually on an as-need basis.

For example: 
- https://github.com/celo-org/charts/pull/202
- https://github.com/celo-org/charts/pull/201