### PR TITLE
Update blockscout metadata crawler image

### DIFF
--- a/charts/blockscout/Chart.yaml
+++ b/charts/blockscout/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: blockscout
-version: 1.3.15
+version: 1.3.16
 appVersion: v2.0.4-beta
 description: Chart which is used to deploy Blockscout for Celo Networks
 home: https://explorer.celo.org

--- a/charts/blockscout/README.md
+++ b/charts/blockscout/README.md
@@ -2,7 +2,7 @@
 
 Chart which is used to deploy Blockscout for Celo Networks
 
-![Version: 1.3.15](https://img.shields.io/badge/Version-1.3.15-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.0.4-beta](https://img.shields.io/badge/AppVersion-v2.0.4--beta-informational?style=flat-square)
+![Version: 1.3.16](https://img.shields.io/badge/Version-1.3.16-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.0.4-beta](https://img.shields.io/badge/AppVersion-v2.0.4--beta-informational?style=flat-square)
 
 - [blockscout](#blockscout)
   - [Chart requirements](#chart-requirements)
@@ -36,7 +36,7 @@ To install/manage a release named `celo-mainnet-fullnode` connected to `mainnet`
 
 ```bash
 # Select the chart release to use
-CHART_RELEASE="oci://us-west1-docker.pkg.dev/celo-testnet/clabs-public-oci/blockscout --version=1.3.15" # Use remote chart and specific version
+CHART_RELEASE="oci://us-west1-docker.pkg.dev/celo-testnet/clabs-public-oci/blockscout --version=1.3.16" # Use remote chart and specific version
 CHART_RELEASE="./" # Use this local folder
 
 # (Only for local chart) Sync helm dependencies
@@ -111,7 +111,7 @@ helm upgrade my-blockscout -f values-alfajores-blockscout2.yaml --namespace=celo
 | blockscout.indexer.strategy | object | `{"rollingUpdate":{"maxSurge":1,"maxUnavailable":0}}` | UpdateStrategy for indexer deployment |
 | blockscout.indexer.terminationGracePeriodSeconds | int | `60` | termination timeout for indexer pod |
 | blockscout.indexer.tracerImplementation | string | `"call_tracer"` | tracer to use to fetch internal transactions - 'js' or 'call_tracer' |
-| blockscout.metadataCrawler | object | `{"discordClusterName":"","enabled":false,"image":{"repository":"gcr.io/celo-testnet/celo-monorepo","tag":"metadata-crawler-77a392216d4927e85ce4b683508fc0539aa92a34"},"schedule":"0 */2 * * *"}` | Configuraton for the metadataCrawler component |
+| blockscout.metadataCrawler | object | `{"discordClusterName":"","enabled":false,"image":{"repository":"us-west1-docker.pkg.dev/devopsre/dev-images/blockscoute-metadata-crawler","tag":"master"},"schedule":"0 */2 * * *"}` | Configuraton for the metadataCrawler component |
 | blockscout.metadataCrawler.discordClusterName | string | `""` | Discord server for notifications |
 | blockscout.metadataCrawler.schedule | string | `"0 */2 * * *"` | Cron schedule for the metadataCrawler |
 | blockscout.shared.db | object | `{"drop":"false"}` | Drop the database on startup |

--- a/charts/blockscout/values.yaml
+++ b/charts/blockscout/values.yaml
@@ -326,8 +326,8 @@ blockscout:
     # -- Cron schedule for the metadataCrawler
     schedule: "0 */2 * * *"
     image:
-      repository: gcr.io/celo-testnet/celo-monorepo
-      tag: metadata-crawler-77a392216d4927e85ce4b683508fc0539aa92a34
+      repository: us-west1-docker.pkg.dev/devopsre/dev-images/blockscoute-metadata-crawler
+      tag: master
     # -- Discord server for notifications
     discordClusterName: ""
 


### PR DESCRIPTION
Updated the version of metadata-crawler image. Updated dockerfile is https://github.com/celo-org/celo-monorepo/pull/10831

The new image reduces the number of vulnerabilities in the container.

From:
```
193 vulnerabilities found in 121 packages
  UNSPECIFIED  18
  LOW          14
  MEDIUM       66
  HIGH         74
  CRITICAL     21
```

To:
```
128 vulnerabilities found in 58 packages
  UNSPECIFIED  4
  LOW          85
  MEDIUM       24
  HIGH         12
  CRITICAL     3
```