### PR TITLE
Update gce-proxy image

### DIFF
--- a/charts/blockscout/Chart.yaml
+++ b/charts/blockscout/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: blockscout
-version: 1.3.16
+version: 1.3.17
 appVersion: v2.0.4-beta
 description: Chart which is used to deploy Blockscout for Celo Networks
 home: https://explorer.celo.org

--- a/charts/blockscout/README.md
+++ b/charts/blockscout/README.md
@@ -2,7 +2,7 @@
 
 Chart which is used to deploy Blockscout for Celo Networks
 
-![Version: 1.3.16](https://img.shields.io/badge/Version-1.3.16-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.0.4-beta](https://img.shields.io/badge/AppVersion-v2.0.4--beta-informational?style=flat-square)
+![Version: 1.3.17](https://img.shields.io/badge/Version-1.3.17-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.0.4-beta](https://img.shields.io/badge/AppVersion-v2.0.4--beta-informational?style=flat-square)
 
 - [blockscout](#blockscout)
   - [Chart requirements](#chart-requirements)
@@ -36,7 +36,7 @@ To install/manage a release named `celo-mainnet-fullnode` connected to `mainnet`
 
 ```bash
 # Select the chart release to use
-CHART_RELEASE="oci://us-west1-docker.pkg.dev/celo-testnet/clabs-public-oci/blockscout --version=1.3.16" # Use remote chart and specific version
+CHART_RELEASE="oci://us-west1-docker.pkg.dev/celo-testnet/clabs-public-oci/blockscout --version=1.3.17" # Use remote chart and specific version
 CHART_RELEASE="./" # Use this local folder
 
 # (Only for local chart) Sync helm dependencies

--- a/charts/blockscout/templates/_helpers.tpl
+++ b/charts/blockscout/templates/_helpers.tpl
@@ -59,7 +59,7 @@ the `volumes` section.
 {{- $port := default .Values.infrastructure.database.proxy.port ((.Database).proxy).port -}}
 {{- if .Values.infrastructure.database.enableCloudSQLProxy -}}
 - name: cloudsql-proxy
-  image: gcr.io/cloudsql-docker/gce-proxy:1.19.1-alpine
+  image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.8.1-alpine
   lifecycle:
     postStart:
       exec:
@@ -149,7 +149,7 @@ the `volumes` section.
 {{- if .Values.infrastructure.database.enableCloudSQLProxy -}}
 {{- $database_host := default .Values.infrastructure.database.proxy.host ((.Database).proxy).connectionName -}}
 - name: cloudsql-proxy
-  image: gcr.io/cloudsql-docker/gce-proxy:1.19.1-alpine
+  image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.8.1-alpine
   lifecycle:
     postStart:
       exec:


### PR DESCRIPTION
Update the gce-proxy image to latest ([source](https://github.com/GoogleCloudPlatform/cloud-sql-proxy#container-images)).

We cannot use distroless image as we require shell for the lifecycle and command executed.

Tested in baklava.