### PR TITLE
Blockscout related tweaks

### DIFF
--- a/charts/blockscout/Chart.yaml
+++ b/charts/blockscout/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: blockscout
-version: 1.3.17
+version: 1.3.18
 appVersion: v2.0.4-beta
 description: Chart which is used to deploy Blockscout for Celo Networks
 home: https://explorer.celo.org

--- a/charts/blockscout/README.md
+++ b/charts/blockscout/README.md
@@ -2,7 +2,7 @@
 
 Chart which is used to deploy Blockscout for Celo Networks
 
-![Version: 1.3.17](https://img.shields.io/badge/Version-1.3.17-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.0.4-beta](https://img.shields.io/badge/AppVersion-v2.0.4--beta-informational?style=flat-square)
+![Version: 1.3.18](https://img.shields.io/badge/Version-1.3.18-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.0.4-beta](https://img.shields.io/badge/AppVersion-v2.0.4--beta-informational?style=flat-square)
 
 - [blockscout](#blockscout)
   - [Chart requirements](#chart-requirements)
@@ -36,7 +36,7 @@ To install/manage a release named `celo-mainnet-fullnode` connected to `mainnet`
 
 ```bash
 # Select the chart release to use
-CHART_RELEASE="oci://us-west1-docker.pkg.dev/celo-testnet/clabs-public-oci/blockscout --version=1.3.17" # Use remote chart and specific version
+CHART_RELEASE="oci://us-west1-docker.pkg.dev/celo-testnet/clabs-public-oci/blockscout --version=1.3.18" # Use remote chart and specific version
 CHART_RELEASE="./" # Use this local folder
 
 # (Only for local chart) Sync helm dependencies
@@ -80,7 +80,7 @@ helm upgrade my-blockscout -f values-alfajores-blockscout2.yaml --namespace=celo
 | blockscout.api.rpcRegion | string | `"api"` | MY_REGION env variable for api pod. Do not change. |
 | blockscout.api.strategy | object | `{"rollingUpdate":{"maxSurge":1,"maxUnavailable":"20%"}}` | UpdateStrategy for api deployment |
 | blockscout.api.suffix | object | `{"enabled":false,"path":""}` | If api component is served at rootPath |
-| blockscout.dbMaintenance | object | `{"enabled":false,"image":{"repository":"us-west1-docker.pkg.dev/devopsre/db-maintenance/db-maintenance-image","tag":"latest"},"schedule":"0 * 1 * *"}` | Configuraton for the database maintenance cronjob |
+| blockscout.dbMaintenance | object | `{"enabled":true,"image":{"repository":"us-west1-docker.pkg.dev/devopsre/db-maintenance/db-maintenance-image","tag":"latest"},"schedule":"0 * 1 * *"}` | Configuraton for the database maintenance cronjob |
 | blockscout.eventStream | object | `{"beanstalkdHost":"","beanstalkdPort":"","beanstalkdTube":"","enabled":false,"livenessProbe":{},"port":4000,"readinessProbe":{},"replicas":0,"resources":{"requests":{"cpu":2,"memory":"1000Mi"}},"strategy":{"rollingUpdate":{"maxSurge":1,"maxUnavailable":0}}}` | Configuraton for the eventStream component |
 | blockscout.eventStream.beanstalkdHost | string | `""` | `BEANSTALKD_HOST` env for eventStream deployment |
 | blockscout.eventStream.beanstalkdPort | string | `""` | `BEANSTALKD_PORT` env for eventStream deployment |

--- a/charts/blockscout/templates/_helpers.tpl
+++ b/charts/blockscout/templates/_helpers.tpl
@@ -130,7 +130,7 @@ the `volumes` section.
 {{- /* Defines init container copying secrets-init to the specified directory. */ -}}
 {{- define "celo.blockscout.initContainer.secrets-init" -}}
 - name: secrets-init
-  image: "doitintl/secrets-init:0.5.0"
+  image: "doitintl/secrets-init:0.4.2"
   args:
     - copy
     - /secrets/

--- a/charts/blockscout/values.yaml
+++ b/charts/blockscout/values.yaml
@@ -333,7 +333,7 @@ blockscout:
 
   # -- Configuraton for the database maintenance cronjob
   dbMaintenance:
-    enabled: false
+    enabled: true
     schedule: "0 * 1 * *"
     image:
       repository: us-west1-docker.pkg.dev/devopsre/db-maintenance/db-maintenance-image


### PR DESCRIPTION
# Description

Two small changes to blockscout charts.

1. Revert `secrets-init` to `0.4.2`
    * `0.5.0` results in zombie processes when the underlying "child" process is killed by k8s OOM signal
2. Enable db maintenance job by default across environments 
    * actually schedules and runs https://github.com/celo-org/data-services/issues/730

(also bumps chart version - ofc) 