### PR TITLE
Replace bash by /bin/sh for odis

### DIFF
--- a/charts/odis-combiner/Chart.yaml
+++ b/charts/odis-combiner/Chart.yaml
@@ -15,7 +15,7 @@ keywords:
   - Celo
   - ODIS
   - Ethereum
-version: 0.2.2
+version: 0.2.3
 maintainers:
   - name: cLabs
     email: devops@clabs.co

--- a/charts/odis-combiner/README.md
+++ b/charts/odis-combiner/README.md
@@ -1,6 +1,6 @@
 # odis-combiner
 
-![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4c00727348979093a76a7aa5b1ba7ea7bf5ac9cf](https://img.shields.io/badge/AppVersion-4c00727348979093a76a7aa5b1ba7ea7bf5ac9cf-informational?style=flat-square)
+![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4c00727348979093a76a7aa5b1ba7ea7bf5ac9cf](https://img.shields.io/badge/AppVersion-4c00727348979093a76a7aa5b1ba7ea7bf5ac9cf-informational?style=flat-square)
 
 Helm chart for deploying Celo ODIS signer in AKS
 

--- a/charts/odis-combiner/templates/deployment.yaml
+++ b/charts/odis-combiner/templates/deployment.yaml
@@ -44,7 +44,7 @@ spec:
               containerPort: {{ include "odis-combiner.port" . }}
               protocol: TCP
           command:
-            - bash
+            - /bin/sh
             - "-c"
             {{- if .Values.command }}
             {{- with .Values.command }}

--- a/charts/odis-signer/Chart.yaml
+++ b/charts/odis-signer/Chart.yaml
@@ -15,7 +15,7 @@ keywords:
   - Celo
   - ODIS
   - Ethereum
-version: 0.2.3
+version: 0.2.4
 maintainers:
   - name: cLabs
     email: devops@clabs.co

--- a/charts/odis-signer/README.md
+++ b/charts/odis-signer/README.md
@@ -1,6 +1,6 @@
 # odis-signer
 
-![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: odis-signer-3.1.1](https://img.shields.io/badge/AppVersion-odis--signer--3.1.1-informational?style=flat-square)
+![Version: 0.2.4](https://img.shields.io/badge/Version-0.2.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: odis-signer-3.1.1](https://img.shields.io/badge/AppVersion-odis--signer--3.1.1-informational?style=flat-square)
 
 Helm chart for deploying Celo ODIS signer
 

--- a/charts/odis-signer/templates/deployment.yaml
+++ b/charts/odis-signer/templates/deployment.yaml
@@ -60,7 +60,7 @@ spec:
               containerPort: {{ include "odis-signer.port" . }}
               protocol: TCP
           command:
-            - bash
+            - /bin/sh
             - "-c"
             {{- if .Values.command }}
             {{- with .Values.command }}


### PR DESCRIPTION
`bash` is typically not available in slim container images. If there is not any bash functionality required in the script, it is preferred to use `/bin/sh` as a more standard and lightweight shell.