### PR TITLE
Fix secondaries etherbase cmdflags

### DIFF
--- a/charts/testnet/Chart.yaml
+++ b/charts/testnet/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 name: testnet
 apiVersion: v2
-version: 0.5.0
+version: 0.5.1
 description: Private Celo network Helm chart for Kubernetes
 home: https://clabs.co
 sources:

--- a/charts/testnet/README.md
+++ b/charts/testnet/README.md
@@ -1,6 +1,6 @@
 # testnet
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.0](https://img.shields.io/badge/AppVersion-v1.0.0-informational?style=flat-square)
+![Version: 0.5.1](https://img.shields.io/badge/Version-0.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.0](https://img.shields.io/badge/AppVersion-v1.0.0-informational?style=flat-square)
 
 Private Celo network Helm chart for Kubernetes
 

--- a/charts/testnet/templates/secondaries.statefulset.yaml
+++ b/charts/testnet/templates/secondaries.statefulset.yaml
@@ -239,7 +239,6 @@ spec:
             --password=/root/.celo/account/accountSecret \
             --unlock=${ACCOUNT_ADDRESS} \
             --mine \
-            --etherbase=${ACCOUNT_ADDRESS} \
             --syncmode=full \
             --consoleformat=json \
             --consoleoutput=stdout \


### PR DESCRIPTION
Fixes the error:

```
Fatal: `etherbase` and `miner.validator` flag should not be used together. `miner.validator` and `tx-fee-recipient` constitute both of `etherbase`' functions
```