### PR TITLE
Fix regex for skipping PVC clean in cronjob

### DIFF
--- a/charts/celo-fullnode/Chart.yaml
+++ b/charts/celo-fullnode/Chart.yaml
@@ -19,7 +19,7 @@ keywords:
   - Validator
   - Ethereum
   - Proof-of-Stake
-version: 0.6.8
+version: 0.6.9
 dependencies:
   - name: common
     repository: oci://us-west1-docker.pkg.dev/devopsre/clabs-public-oci

--- a/charts/celo-fullnode/templates/delete-pod-cronjob.yaml
+++ b/charts/celo-fullnode/templates/delete-pod-cronjob.yaml
@@ -36,7 +36,7 @@ spec:
               | grep -E "^Name:.*$|^Used By:.*$" \
               | grep -B 1 "<none>" \
               | grep -E "^Name:.*$" \
-              | grep -v "{{ printf "data-%s-%d" (include "common.fullname" .) (.Values.deletePodCronJob.podIndex | int) }}" \
+              | grep -vE "{{ printf "data-%s-%d" (include "common.fullname" .) (.Values.deletePodCronJob.podIndex | int) }}$" \
               {{- range .Values.deletePodCronJob.extraSkippedPvc }}
               | grep -v "{{ printf "data-%s-%d" (include "common.fullname" $) (. | int) }}" \
               {{- end }}


### PR DESCRIPTION
Fix the regex of skipped PVC to delete. We need to add an end string anchor (`$`), so for example `rc1-fullnodes-10` is not skipped by `rc1-fullnodes-1` grep.