### PR TITLE
Fix fullnodes diff

### DIFF
--- a/.github/workflows/helm_test.yml
+++ b/.github/workflows/helm_test.yml
@@ -198,19 +198,19 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - name: "Get GitHub Token from Akeyless"
-        id: get_auth_token
-        uses:
-          docker://us-west1-docker.pkg.dev/devopsre/akeyless-public/akeyless-action:latest
-        with:
-          api-url: https://api.gateway.akeyless.celo-networks-dev.org
-          access-id: p-kf9vjzruht6l
-          dynamic-secrets: '{"/dynamic-secrets/keys/github/charts/contents=write,pull_requests=write":"PAT"}'
+      # - name: "Get GitHub Token from Akeyless"
+      #   id: get_auth_token
+      #   uses:
+      #     docker://us-west1-docker.pkg.dev/devopsre/akeyless-public/akeyless-action:latest
+      #   with:
+      #     api-url: https://api.gateway.akeyless.celo-networks-dev.org
+      #     access-id: p-kf9vjzruht6l
+      #     dynamic-secrets: '{"/dynamic-secrets/keys/github/charts/contents=write,pull_requests=write":"PAT"}'
 
       - name: "Checkout current PR"
         uses: actions/checkout@v4
-        with:
-          token: ${{ env.PAT }}
+      #  with:
+      #    token: ${{ env.PAT }}
 
       - name: "Install helm-docs"
         run: |

--- a/charts/celo-fullnode/Chart.yaml
+++ b/charts/celo-fullnode/Chart.yaml
@@ -19,11 +19,11 @@ keywords:
   - Validator
   - Ethereum
   - Proof-of-Stake
-version: 0.6.12
+version: 0.6.11
 dependencies:
   - name: common
     repository: oci://us-west1-docker.pkg.dev/devopsre/clabs-public-oci
-    version: 0.5.1
+    version: 0.5.0
 maintainers:
   - name: cLabs
     email: devops@clabs.co

--- a/charts/celo-fullnode/Chart.yaml
+++ b/charts/celo-fullnode/Chart.yaml
@@ -19,11 +19,11 @@ keywords:
   - Validator
   - Ethereum
   - Proof-of-Stake
-version: 0.6.11
+version: 0.6.12
 dependencies:
   - name: common
     repository: oci://us-west1-docker.pkg.dev/devopsre/clabs-public-oci
-    version: 0.5.0
+    version: 0.5.1
 maintainers:
   - name: cLabs
     email: devops@clabs.co

--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: common
-version: 0.5.0
+version: 0.5.1
 type: library
 home: https://celo.org
 icon: https://pbs.twimg.com/profile_images/1613170131491848195/InjXBNx9_400x400.jpg

--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -2,7 +2,7 @@
 
 Helm chart with helper templates and functions for Celo nodes. Import into your chart with `dependencies` and use the templates and functions
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
+![Version: 0.5.1](https://img.shields.io/badge/Version-0.5.1-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
 
 - [common](#common)
   - [Chart releases](#chart-releases)
@@ -23,7 +23,7 @@ To import this chart into your chart, add the following to your `requirements.ya
 dependencies:
   - name: common
     repository: oci://us-west1-docker.pkg.dev/celo-testnet/clabs-public-oci
-    version: 0.5.0
+    version: 0.5.1
 ```
 
 ## Values

--- a/charts/common/templates/_helpers.tpl
+++ b/charts/common/templates/_helpers.tpl
@@ -265,6 +265,7 @@ fi
     protocol: UDP
   - name: ethereum-{{ $port }}
     containerPort: {{ $port }}
+    protocol: TCP
   {{- end }}
   {{- else }}
   - name: discovery
@@ -272,16 +273,20 @@ fi
     protocol: UDP
   - name: ethereum
     containerPort: 30303
+    protocol: TCP
   {{- end }}
   {{- if .expose }}
   - name: rpc
     containerPort: 8545
+    protocol: TCP
   - name: ws
     containerPort: {{ default .Values.geth.ws_port .ws_port }}
+    protocol: TCP
   {{- end }}
   {{- if .pprof }}
   - name: pprof
     containerPort: {{ .pprof_port }}
+    protocol: TCP
   {{- end }}
   {{- $resources := default .Values.geth.resources .resources -}}
   {{- with $resources }}


### PR DESCRIPTION
Fix fullnodes diff, checked with `kubectl diff`.

Also, do not use Akeyless token for Helm docs, as this will trigger a new WF execution that will fail (a synchronize event by [akeyless-target-app](https://github.com/apps/akeyless-target-app) - the repository's GITHUB_TOKEN does not trigger a new WF: https://github.com/marketplace/actions/git-auto-commit#commits-made-by-this-action-do-not-trigger-new-workflow-runs): 
 
![Screenshot 2024-04-09 at 14 05 39](https://github.com/celo-org/charts/assets/35505302/9166274c-00c1-46a8-9156-cb29d6a37c17)

