### PR TITLE
[Op-node]: Support replicas

### DIFF
--- a/charts/op-node/Chart.yaml
+++ b/charts/op-node/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 name: op-node
 apiVersion: v2
-version: 0.0.3
+version: 0.0.4
 description: Celo implementation for op-node consensus engine (Optimism Rollup)
 home: https://clabs.co
 sources:

--- a/charts/op-node/README.md
+++ b/charts/op-node/README.md
@@ -1,6 +1,6 @@
 # op-node
 
-![Version: 0.0.3](https://img.shields.io/badge/Version-0.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.0](https://img.shields.io/badge/AppVersion-v1.0.0-informational?style=flat-square)
+![Version: 0.0.4](https://img.shields.io/badge/Version-0.0.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.0](https://img.shields.io/badge/AppVersion-v1.0.0-informational?style=flat-square)
 
 Celo implementation for op-node consensus engine (Optimism Rollup)
 Initially based on [dysnix/charts/op-node](https://github.com/dysnix/charts/tree/main/dysnix/op-node).
@@ -99,6 +99,7 @@ Initially based on [dysnix/charts/op-node](https://github.com/dysnix/charts/tree
 | persistence.type | string | `"pvc"` |  |
 | podSecurityContext | object | `{}` |  |
 | readinessProbe.enabled | bool | `false` |  |
+| replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
 | securityContext.allowPrivilegeEscalation | bool | `false` |  |
 | securityContext.capabilities.drop[0] | string | `"ALL"` |  |
@@ -113,8 +114,10 @@ Initially based on [dysnix/charts/op-node](https://github.com/dysnix/charts/tree
 | services.metrics.publishNotReadyAddresses | bool | `true` |  |
 | services.metrics.type | string | `"ClusterIP"` |  |
 | services.p2p.annotations | object | `{}` |  |
+| services.p2p.clusterIPs | list | `[]` |  |
 | services.p2p.enabled | bool | `true` |  |
-| services.p2p.loadBalancerIP | string | `""` |  |
+| services.p2p.loadBalancerIPs | list | `[]` |  |
+| services.p2p.nodePorts | list | `[]` |  |
 | services.p2p.port | int | `9222` |  |
 | services.p2p.publishNotReadyAddresses | bool | `true` |  |
 | services.p2p.type | string | `"NodePort"` |  |

--- a/charts/op-node/templates/configmap-scripts.yaml
+++ b/charts/op-node/templates/configmap-scripts.yaml
@@ -7,6 +7,8 @@ metadata:
 data:
   download-rollup-genesis.sh: |-
     {{- include (print $.Template.BasePath "/scripts/_download-rollup-genesis.tpl") . | nindent 4 }}
+  split-jwt.sh: |-
+    {{- include (print $.Template.BasePath "/scripts/_split-jwt.tpl") . | nindent 4 }}
 {{- if or .Values.initFromGCS.enabled }}
   gcs-env.sh: |-
     {{- include (print $.Template.BasePath "/scripts/_gcs-env.tpl") . | nindent 4 }}

--- a/charts/op-node/templates/scripts/_download-rollup-genesis.tpl
+++ b/charts/op-node/templates/scripts/_download-rollup-genesis.tpl
@@ -1,10 +1,11 @@
 #!/usr/bin/env sh
 set -e
 
-if [ ! -f /celo/.initialized ]; then
-    wget -qO /celo/genesis.json "{{ .Values.init.genesis.url }}"
-    wget -qO /celo/rollup.json "{{ .Values.init.rollup.url }}"
-    touch /celo/.initialized
+datadir="{{ .Values.persistence.mountPath | default .Values.config.rollup.config }}"
+if [ ! -f $datadir/.initialized ]; then
+    wget -qO $datadir/genesis.json "{{ .Values.init.genesis.url }}"
+    wget -qO $datadir/rollup.json "{{ .Values.init.rollup.url }}"
+    touch $datadir/.initialized
     echo "Successfully downloaded genesis and rollup files"
 else
     echo "Already downloaded, skipping."

--- a/charts/op-node/templates/scripts/_split-jwt.tpl
+++ b/charts/op-node/templates/scripts/_split-jwt.tpl
@@ -1,0 +1,19 @@
+#!/usr/bin/env sh
+
+# Get Replica ID from hostname
+RID=$(echo $HOSTNAME | sed 's/{{ .Release.Name }}-//')
+datadir="{{ .Values.persistence.mountPath | default .Values.config.rollup.config }}"
+# Split the jwt keys based on the comma and get the $RID-th key
+cat /secrets/jwt.hex | tr ',' '\n' | sed -n "$((RID + 1))p" | tr -d '\n' > "$datadir/jwt.hex"
+# If the jwt is not defined for this index, use the first jwt key
+if [ ! -s "$datadir/jwt.hex" ]; then
+  cat /secrets/jwt.hex | tr ',' '\n' | head -n 1 | tr -d '\n' > "$datadir/jwt.hex"
+fi
+
+# Split the advertised addresses based on the comma and get the $RID-th key
+advertiseIp=$(echo "{{ .Values.config.p2p.advertiseIP }}" | tr ',' '\n' | sed -n "$((RID + 1))p" | tr -d '\n')
+# Check if not empty
+if [ -n "$advertiseIp" ]; then
+  echo "Setting advertise address to $advertiseIp"
+  echo "$advertiseIp" > "$datadir/advertiseIP"
+fi

--- a/charts/op-node/templates/service-p2p.yaml
+++ b/charts/op-node/templates/service-p2p.yaml
@@ -1,9 +1,24 @@
-{{- with .Values.services.p2p }}
+{{- $replicas := .Values.replicaCount }}
+{{ range $index, $e := until (int $replicas) }}
+{{- with $.Values.services.p2p }}
 {{- if and .enabled (not $.Values.config.p2p.useHostPort) }}
+{{- $loadBalancerIp := "" }}
+{{- $clusterIp := "" }}
+{{- $nodePort := "" }}
+{{- if lt $index (len .loadBalancerIPs) }}
+  {{- $loadBalancerIp = index .loadBalancerIPs $index }}
+{{- end }}
+{{- if lt $index (len .clusterIPs) }}
+  {{- $clusterIp = index .clusterIPs $index }}
+{{- end }}
+{{- if lt $index (len .nodePorts) }}
+  {{- $nodePort = index .nodePorts $index }}
+{{- end }}
+---
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "op-node.fullname" $ }}-p2p
+  name: {{ include "op-node.fullname" $ }}-p2p-{{ $index }}
   {{- with .annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -13,10 +28,10 @@ metadata:
     {{- include "op-node.labels" $ | nindent 4 }}
 spec:
   type: {{ .type }}
-  {{- with .loadBalancerIP }}
+  {{- with $loadBalancerIp }}
   loadBalancerIP: {{ . }}
   {{- end }}
-  {{- with .clusterIP }}
+  {{- with $clusterIp }}
   clusterIP: {{ . }}
   {{- end }}
   {{- with .externalTrafficPolicy }}
@@ -33,17 +48,19 @@ spec:
       port: {{ .port }}
       targetPort: p2p-tcp
       protocol: TCP
-      {{- with .nodePort }}
+      {{- with $nodePort }}
       nodePort: {{ . }}
       {{- end }}
     - name: p2p-udp
       port: {{ .port }}
       targetPort: p2p-udp
       protocol: UDP
-      {{- with .nodePort }}
+      {{- with $nodePort }}
       nodePort: {{ . }}
       {{- end }}
   selector:
     {{- include "op-node.selectorLabels" $ | nindent 4 }}
+    statefulset.kubernetes.io/pod-name: {{ template "op-node.fullname" $ }}-{{ $index }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/op-node/templates/service-p2p.yaml
+++ b/charts/op-node/templates/service-p2p.yaml
@@ -2,14 +2,14 @@
 {{ range $index, $e := until (int $replicas) }}
 {{- with $.Values.services.p2p }}
 {{- if and .enabled (not $.Values.config.p2p.useHostPort) }}
-{{- $loadBalancerIp := "" }}
-{{- $clusterIp := "" }}
+{{- $loadBalancerIP := "" }}
+{{- $clusterIP := "" }}
 {{- $nodePort := "" }}
 {{- if lt $index (len .loadBalancerIPs) }}
-  {{- $loadBalancerIp = index .loadBalancerIPs $index }}
+  {{- $loadBalancerIP = index .loadBalancerIPs $index }}
 {{- end }}
 {{- if lt $index (len .clusterIPs) }}
-  {{- $clusterIp = index .clusterIPs $index }}
+  {{- $clusterIP = index .clusterIPs $index }}
 {{- end }}
 {{- if lt $index (len .nodePorts) }}
   {{- $nodePort = index .nodePorts $index }}
@@ -28,10 +28,10 @@ metadata:
     {{- include "op-node.labels" $ | nindent 4 }}
 spec:
   type: {{ .type }}
-  {{- with $loadBalancerIp }}
+  {{- with $loadBalancerIP }}
   loadBalancerIP: {{ . }}
   {{- end }}
-  {{- with $clusterIp }}
+  {{- with $clusterIP }}
   clusterIP: {{ . }}
   {{- end }}
   {{- with .externalTrafficPolicy }}

--- a/charts/op-node/templates/statefulset.yaml
+++ b/charts/op-node/templates/statefulset.yaml
@@ -9,6 +9,7 @@ metadata:
   labels:
     {{- include "op-node.labels" . | nindent 4 }}
 spec:
+  replicas: {{ .Values.replicaCount }}
   serviceName: {{ template "op-node.name" . }}
   updateStrategy:
     {{- toYaml .Values.updateStrategy | nindent 4 }}
@@ -68,6 +69,21 @@ spec:
         - name: data
           mountPath: {{ .Values.persistence.mountPath | default .Values.config.rollup.config }}
       {{- end }}
+      - name: split-jwt
+        image: "{{ .Values.init.image.repository }}:{{ .Values.init.image.tag }}"
+        imagePullPolicy: {{ .Values.init.image.pullPolicy | quote }}
+        {{- with .Values.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        command: ["sh", "/scripts/split-jwt.sh"]
+        volumeMounts:
+        - name: scripts
+          mountPath: /scripts
+        - name: secrets
+          mountPath: /secrets
+        - name: data
+          mountPath: {{ .Values.persistence.mountPath | default .Values.config.rollup.config }}
       {{- with .Values.initContainers }}
         {{- tpl (toYaml . | nindent 6) $ }}
       {{- end }}
@@ -97,7 +113,7 @@ spec:
             --l1.beacon={{ . }} \
             {{- end }}
             --l2={{ .Values.config.l2.url }} \
-            --l2.jwt-secret=/secrets/jwt.hex \
+            --l2.jwt-secret={{ .Values.persistence.mountPath | default .Values.config.rollup.config }}/jwt.hex \
             --rpc.addr=0.0.0.0 \
             --rpc.port={{ .Values.config.port }} \
             {{- if .Values.config.enableAdmin }}
@@ -191,8 +207,6 @@ spec:
           {{- include "op-node.healthcheck" (list $ .Values.readinessProbe) | nindent 10 }}
         {{- end }}
         volumeMounts:
-        - name: secrets
-          mountPath: /secrets
         - name: data
           mountPath: {{ .Values.persistence.mountPath | default .Values.config.rollup.config }}
         resources:

--- a/charts/op-node/templates/statefulset.yaml
+++ b/charts/op-node/templates/statefulset.yaml
@@ -105,6 +105,11 @@ spec:
         {{- end }}
         args:
         - |
+          datadir="{{ .Values.persistence.mountPath | default .Values.config.rollup.config }}"
+          advertiseIpFlag=""
+          if [ -f $datadir/advertiseIP ]; then
+            advertiseIpFlag="--p2p.advertise.ip=$(cat $datadir/advertiseIP)"
+          fi
           exec op-node \
             --l1={{ .Values.config.l1.url }} \
             --l1.trustrpc={{ .Values.config.l1.trustrpc }} \
@@ -156,9 +161,7 @@ spec:
             {{- if .Values.config.p2p.nat }}
             --p2p.nat \
             {{- end }}
-            {{- if .Values.config.p2p.advertiseIP }}
-            --p2p.advertise.ip={{ .Values.config.p2p.advertiseIP }} \
-            {{- end }}
+            $advertiseIpFlag \
             --p2p.listen.tcp={{ .Values.config.p2p.port }} \
             --p2p.listen.udp={{ .Values.config.p2p.port }} \
             --p2p.listen.ip=0.0.0.0 \

--- a/charts/op-node/values.yaml
+++ b/charts/op-node/values.yaml
@@ -8,6 +8,9 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+# Number of op-node replicas. Must be 1 if sequencer is enabled
+replicaCount: 1
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true
@@ -59,7 +62,9 @@ services:
   p2p:
     enabled: true
     type: NodePort
-    loadBalancerIP: ""
+    loadBalancerIPs: []
+    clusterIPs: []
+    nodePorts: []
     port: 9222
     # it's better to set nodePort equal to .Values.config.node.p2p.port when the svc type is "NodePort"
     # nodePort: 9222


### PR DESCRIPTION
Support replicas on op-node chart. Not compatible if sequencer is enabled (anyway sequencer (active) instances must be 1).

Pending op-geth chart changes to match op-node multi-replica setup.