### PR TITLE
Support for using same port for ws and http

### DIFF
--- a/charts/op-geth/Chart.yaml
+++ b/charts/op-geth/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 name: op-geth
 apiVersion: v2
-version: 0.0.5
+version: 0.1.0
 description: Celo implementation for op-geth execution engine (Optimism Rollup)
 home: https://clabs.co
 sources:

--- a/charts/op-geth/README.md
+++ b/charts/op-geth/README.md
@@ -1,6 +1,6 @@
 # op-geth
 
-![Version: 0.0.5](https://img.shields.io/badge/Version-0.0.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.0](https://img.shields.io/badge/AppVersion-v1.0.0-informational?style=flat-square)
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.0](https://img.shields.io/badge/AppVersion-v1.0.0-informational?style=flat-square)
 
 Celo implementation for op-geth execution engine (Optimism Rollup)
 Initially based on [dysnix/charts/op-geth](https://github.com/dysnix/charts/tree/main/dysnix/op-geth).
@@ -63,7 +63,7 @@ Initially based on [dysnix/charts/op-geth](https://github.com/dysnix/charts/tree
 | config.ws.api[2] | string | `"web3"` |  |
 | config.ws.enabled | bool | `false` |  |
 | config.ws.origins[0] | string | `"*"` |  |
-| config.ws.port | int | `8546` |  |
+| config.ws.port | int | `8545` |  |
 | enableServiceLinks | bool | `false` |  |
 | extraArgs | list | `[]` |  |
 | extraInitContainers | list | `[]` |  |
@@ -93,6 +93,7 @@ Initially based on [dysnix/charts/op-geth](https://github.com/dysnix/charts/tree
 | init.jwt.image.pullPolicy | string | `"IfNotPresent"` |  |
 | init.jwt.image.repository | string | `"alpine"` |  |
 | init.jwt.image.tag | float | `3.19` |  |
+| init.rollup.enabled | bool | `false` |  |
 | init.rollup.url | string | `""` |  |
 | initFromS3.enabled | bool | `false` |  |
 | initFromS3.force | bool | `false` |  |
@@ -160,15 +161,16 @@ Initially based on [dysnix/charts/op-geth](https://github.com/dysnix/charts/tree
 | services.metrics.publishNotReadyAddresses | bool | `true` |  |
 | services.metrics.type | string | `"ClusterIP"` |  |
 | services.p2p.annotations | object | `{}` |  |
+| services.p2p.clusterIPs | list | `[]` |  |
 | services.p2p.enabled | bool | `true` |  |
-| services.p2p.loadBalancerIP | string | `""` |  |
+| services.p2p.loadBalancerIPs | list | `[]` |  |
 | services.p2p.port | int | `30303` |  |
 | services.p2p.publishNotReadyAddresses | bool | `true` |  |
-| services.p2p.type | string | `"NodePort"` |  |
+| services.p2p.type | string | `"ClusterIP"` |  |
 | services.rpc.enabled | bool | `true` |  |
 | services.rpc.httpPort | int | `8545` |  |
 | services.rpc.type | string | `"ClusterIP"` |  |
-| services.rpc.wsPort | int | `8546` |  |
+| services.rpc.wsPort | int | `8545` |  |
 | sidecarContainers | list | `[]` |  |
 | startupProbe.enabled | bool | `false` |  |
 | startupProbe.exec.command[0] | string | `"sh"` |  |

--- a/charts/op-geth/templates/scripts/_init-genesis.tpl
+++ b/charts/op-geth/templates/scripts/_init-genesis.tpl
@@ -3,8 +3,12 @@ set -e
 
 datadir="{{ .Values.persistence.mountPath | default .Values.config.datadir }}"
 if [ ! -f $datadir/.initialized ]; then
-    wget -qO $datadir/genesis.json "{{ .Values.init.genesis.url }}"
+    {{- if .Values.init.rollup.enabled }}
     wget -qO $datadir/rollup.json "{{ .Values.init.rollup.url }}"
+    echo "Successfully downloaded rollup.json"
+    {{- end }}
+    {{- if .Values.init.genesis.enabled }}
+    wget -qO $datadir/genesis.json "{{ .Values.init.genesis.url }}"
     {{- $stateScheme := "" }}
     {{- if .Values.config.state }}
     {{- if .Values.config.state.scheme }}
@@ -12,8 +16,9 @@ if [ ! -f $datadir/.initialized ]; then
     {{- end }}
     {{- end }}
     geth --datadir={{ .Values.config.datadir }}{{ $stateScheme }} init $datadir/genesis.json
-    touch $datadir/.initialized
     echo "Successfully initialized from genesis file"
+    {{- end }}
+    touch $datadir/.initialized
 else
     echo "Already initialized, skipping."
 fi

--- a/charts/op-geth/templates/service-p2p.yaml
+++ b/charts/op-geth/templates/service-p2p.yaml
@@ -1,9 +1,19 @@
-{{- with .Values.services.p2p }}
+{{- $replicas := .Values.replicaCount }}
+{{ range $index, $e := until (int $replicas) }}
+{{- with $.Values.services.p2p }}
 {{- if and .enabled (not $.Values.config.useHostPort) }}
+{{- $loadBalancerIP := "" }}
+{{- $clusterIP := "" }}
+{{- if lt $index (len .loadBalancerIPs) }}
+  {{- $loadBalancerIP = index .loadBalancerIPs $index }}
+{{- end }}
+{{- if lt $index (len .clusterIPs) }}
+  {{- $clusterIP = index .clusterIPs $index }}
+{{- end }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "op-geth.fullname" $ }}-p2p
+  name: {{ include "op-geth.fullname" $ }}-p2p-{{ $index }}
   {{- with .annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -13,10 +23,10 @@ metadata:
     {{- include "op-geth.labels" $ | nindent 4 }}
 spec:
   type: {{ .type }}
-  {{- with .loadBalancerIP }}
+  {{- with $loadBalancerIP }}
   loadBalancerIP: {{ . }}
   {{- end }}
-  {{- with .clusterIP }}
+  {{- with $clusterIP }}
   clusterIP: {{ . }}
   {{- end }}
   {{- with .externalTrafficPolicy }}
@@ -33,17 +43,12 @@ spec:
       port: {{ .port }}
       targetPort: p2p-tcp
       protocol: TCP
-      {{- with .nodePort }}
-      nodePort: {{ . }}
-      {{- end }}
     - name: p2p-udp
       port: {{ .port }}
       targetPort: p2p-udp
       protocol: UDP
-      {{- with .nodePort }}
-      nodePort: {{ . }}
-      {{- end }}
   selector:
     {{- include "op-geth.selectorLabels" $ | nindent 4 }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/op-geth/templates/service-rpc.yaml
+++ b/charts/op-geth/templates/service-rpc.yaml
@@ -32,7 +32,7 @@ spec:
     - name: http
       port: {{ .httpPort }}
       targetPort: http
-    {{- if $.Values.config.ws.enabled }}
+    {{- if and $.Values.config.ws.enabled (and (ne .httpPort .wsPort) (ne .Values.config.http.port .Values.config.http.port)) }}
     - name: ws
       port: {{ .wsPort }}
       targetPort: ws

--- a/charts/op-geth/templates/statefulset.yaml
+++ b/charts/op-geth/templates/statefulset.yaml
@@ -73,7 +73,7 @@ spec:
         - name: data
           mountPath: /data
       {{- end }}
-      {{- if .Values.init.genesis.enabled }}
+      {{- if or .Values.init.genesis.enabled .Values.init.rollup.enabled }}
       - name: init-genesis
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
@@ -263,7 +263,7 @@ spec:
           containerPort: {{ .Values.config.http.port }}
         - name: authrpc
           containerPort: {{ .Values.config.authrpc.port }}
-        {{- if .Values.config.ws.enabled }}
+        {{- if and .Values.config.ws.enabled (ne .Values.config.http.port .Values.config.ws.port) }}
         - name: ws
           containerPort: {{ .Values.config.ws.port }}
         {{- end }}

--- a/charts/op-geth/values.yaml
+++ b/charts/op-geth/values.yaml
@@ -122,7 +122,7 @@ services:
     enabled: true
     type: ClusterIP
     httpPort: 8545
-    wsPort: 8546
+    wsPort: 8545
   authrpc:
     enabled: true
     type: ClusterIP
@@ -137,10 +137,10 @@ services:
     publishNotReadyAddresses: true
   p2p:
     enabled: true       # disable if you are not using "snap" syncmode
-    type: NodePort
-    loadBalancerIP: ""
+    type: ClusterIP
+    loadBalancerIPs: []
+    clusterIPs: []
     port: 30303
-    # nodePort: 30303   # exposed port of the node, must be unique across multiple node deployments
     annotations: {}
     publishNotReadyAddresses: true
 ingress:
@@ -276,7 +276,7 @@ config:
     api: ["eth", "net", "web3"]
   ws:
     enabled: false
-    port: 8546
+    port: 8545
     origins: ["*"]
     api: ["eth", "net", "web3"]
   authrpc:
@@ -315,6 +315,7 @@ init:
     enabled: false
     url: ""
   rollup:
+    enabled: false
     url: ""
   jwt:
     image:


### PR DESCRIPTION
Support having same port for http and ws. The service and container ports for both (http/ws) are decoupled, but I think makes sense for easiness keeping those "paired" (i.e.: if you use same port at container level, use same port at service level, and otherwise)