### PR TITLE
Fix .extrasetup function on celo-fullnode

### DIFF
--- a/charts/celo-fullnode/Chart.yaml
+++ b/charts/celo-fullnode/Chart.yaml
@@ -19,7 +19,7 @@ keywords:
   - Validator
   - Ethereum
   - Proof-of-Stake
-version: 0.7.1
+version: 0.7.2
 dependencies:
   - name: common
     repository: oci://us-west1-docker.pkg.dev/devopsre/clabs-public-oci

--- a/charts/celo-fullnode/templates/_helpers.tpl
+++ b/charts/celo-fullnode/templates/_helpers.tpl
@@ -65,7 +65,7 @@ NAT_FLAG="--nat=extip:${PUBLIC_IP}"
 {{- if .Values.geth.increase_timeouts }}
 ADDITIONAL_FLAGS="${ADDITIONAL_FLAGS} --http.timeout.read 600 --http.timeout.write 600 --http.timeout.idle 2400"
 {{- end }}
-{{- .Values.geth.extra_setup }}
+{{ .Values.geth.extra_setup }}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
There were a bug with `celo-fullnode.extra_setup` helper function removing initial new lines for provided extra_setup values.