### PR TITLE
L2OutputOracle contract address using initContainer

### DIFF
--- a/charts/op-proposer/Chart.yaml
+++ b/charts/op-proposer/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 name: op-proposer
 apiVersion: v2
-version: 0.0.1
+version: 0.0.2
 description: Celo implementation for op-proposer client (Optimism Rollup)
 home: https://clabs.co
 sources:

--- a/charts/op-proposer/README.md
+++ b/charts/op-proposer/README.md
@@ -1,6 +1,6 @@
 # op-proposer
 
-![Version: 0.0.1](https://img.shields.io/badge/Version-0.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.0](https://img.shields.io/badge/AppVersion-v1.0.0-informational?style=flat-square)
+![Version: 0.0.2](https://img.shields.io/badge/Version-0.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.0](https://img.shields.io/badge/AppVersion-v1.0.0-informational?style=flat-square)
 
 Celo implementation for op-proposer client (Optimism Rollup)
 
@@ -51,6 +51,11 @@ Celo implementation for op-proposer client (Optimism Rollup)
 | ingress.enabled | bool | `false` |  |
 | ingress.hosts | list | `[]` |  |
 | ingress.tls | list | `[]` |  |
+| init.contracts.enabled | bool | `false` |  |
+| init.contracts.image.pullPolicy | string | `"IfNotPresent"` |  |
+| init.contracts.image.repository | string | `"alpine"` |  |
+| init.contracts.image.tag | float | `3.19` |  |
+| init.contracts.url | string | `""` |  |
 | initContainers | list | `[]` |  |
 | livenessProbe.enabled | bool | `true` |  |
 | livenessProbe.failureThreshold | int | `3` |  |

--- a/charts/op-proposer/templates/statefulset.yaml
+++ b/charts/op-proposer/templates/statefulset.yaml
@@ -53,6 +53,24 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       initContainers:
+      {{- if .Values.init.contracts.enabled }}
+      - name: contracts
+        image: {{ .Values.init.contracts.image.repository }}:{{ .Values.init.contracts.image.tag }}
+        imagePullPolicy: {{ .Values.init.contracts.image.pullPolicy | quote }}
+        command:
+        - /bin/sh
+        - -c
+        args:
+        - |
+          datadir=/contracts
+          wget -qO $datadir/deployment-l1.json "{{ .Values.init.contracts.url }}"
+          L2OutputOracleProxy=$(cat $datadir/deployment-l1.json | grep L2OutputOracleProxy | cut -d'"' -f4)
+          echo $L2OutputOracleProxy > $datadir/L2OutputOracleProxy
+          echo "L2OutputOracleProxy: $L2OutputOracleProxy"
+        volumeMounts:
+        - name: contracts
+          mountPath: /contracts
+      {{- end }}
       {{- with .Values.initContainers }}
         {{- tpl (toYaml . | nindent 6) $ }}
       {{- end }}
@@ -74,11 +92,12 @@ spec:
         {{- end }}
         args:
         - |
+          [ -f /contracts/L2OutputOracleProxy ] && L2OutputOracleProxy=$(cat /contracts/L2OutputOracleProxy) || L2OutputOracleProxy={{ .Values.config.L2OutputOracle }}
           exec op-proposer \
             --poll-interval={{ .Values.config.pollInterval }} \
             --rpc.port={{ .Values.config.rpc.port }} \
             --rollup-rpc={{ .Values.config.rollupRpc }} \
-            --l2oo-address={{ .Values.config.L2OutputOracle }} \
+            --l2oo-address=$L2OutputOracleProxy \
             {{- if .Values.config.privateKey }}
             --private-key=$(cat /secrets/privateKey) \
             {{- end }}
@@ -110,6 +129,8 @@ spec:
         volumeMounts:
         - name: secrets
           mountPath: /secrets
+        - name: contracts
+          mountPath: /contracts
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
       {{- with .Values.sidecarContainers }}
@@ -119,3 +140,5 @@ spec:
       - name: secrets
         secret:
           secretName: {{ template "op-proposer.fullname" . }}
+      - name: contracts
+        emptyDir: {}

--- a/charts/op-proposer/values.yaml
+++ b/charts/op-proposer/values.yaml
@@ -124,6 +124,15 @@ nodeSelector: {}
 
 tolerations: []
 
+init:
+  contracts:
+    enabled: false
+    image:
+      repository: alpine
+      tag: 3.19
+      pullPolicy: IfNotPresent
+    url: ""
+
 ## Main op-proposer config
 config:
   L2OutputOracle: ""                                                         # Address of the L2OutputOracle contract


### PR DESCRIPTION
Adding an initContainer that can fetch L1 contract deployment json file from an url, and extract from there the address form `L2OutputOracleProxy` to be used for the cmdflag. Alternatively it is possible to provide the `config.L2OutputOracle` as it is now.