### PR TITLE
Support providing existing secrets on op-proposer

### DIFF
--- a/charts/op-proposer/Chart.yaml
+++ b/charts/op-proposer/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 name: op-proposer
 apiVersion: v2
-version: 0.0.1
+version: 0.1.0
 description: Celo implementation for op-proposer client (Optimism Rollup)
 home: https://clabs.co
 sources:

--- a/charts/op-proposer/README.md
+++ b/charts/op-proposer/README.md
@@ -1,6 +1,6 @@
 # op-proposer
 
-![Version: 0.0.2](https://img.shields.io/badge/Version-0.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.0](https://img.shields.io/badge/AppVersion-v1.0.0-informational?style=flat-square)
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.0](https://img.shields.io/badge/AppVersion-v1.0.0-informational?style=flat-square)
 
 Celo implementation for op-proposer client (Optimism Rollup)
 
@@ -27,7 +27,6 @@ Celo implementation for op-proposer client (Optimism Rollup)
 | command | list | `[]` |  |
 | config.L2OutputOracle | string | `""` |  |
 | config.activeSecuencerCheckDuration | string | `"2m0s"` |  |
-| config.l1Url | string | `""` |  |
 | config.logs.color | bool | `false` |  |
 | config.logs.format | string | `"json"` |  |
 | config.logs.level | string | `"info"` |  |
@@ -35,7 +34,6 @@ Celo implementation for op-proposer client (Optimism Rollup)
 | config.metrics.enabled | bool | `false` |  |
 | config.metrics.port | int | `7300` |  |
 | config.pollInterval | string | `"12s"` |  |
-| config.privateKey | string | `""` |  |
 | config.rollupRpc | string | `"http://localhost:8547"` |  |
 | config.rpc.addr | string | `"0.0.0.0"` |  |
 | config.rpc.enabledAdmin | bool | `false` |  |
@@ -70,6 +68,12 @@ Celo implementation for op-proposer client (Optimism Rollup)
 | podSecurityContext | object | `{}` |  |
 | readinessProbe.enabled | bool | `false` |  |
 | resources | object | `{}` |  |
+| secrets.l1Url.secretKey | string | `""` |  |
+| secrets.l1Url.secretName | string | `""` |  |
+| secrets.l1Url.value | string | `""` |  |
+| secrets.privateKey.secretKey | string | `""` |  |
+| secrets.privateKey.secretName | string | `""` |  |
+| secrets.privateKey.value | string | `""` |  |
 | securityContext.allowPrivilegeEscalation | bool | `false` |  |
 | securityContext.capabilities.drop[0] | string | `"ALL"` |  |
 | securityContext.privileged | bool | `false` |  |

--- a/charts/op-proposer/ci/ct-values.yaml
+++ b/charts/op-proposer/ci/ct-values.yaml
@@ -2,7 +2,7 @@
 secrets:
   # Private Key for the proposer. Either provide the secret name and key or the value directly. If value is not empty, it will have precedence over the secret.
   privateKey:
-    secretName: privateKeySecret
+    secretName: private-key-secret
     secretKey: privateKeyKey
   # L1 URL for the proposer. Either provide the secret name and key or the value directly. If value is not empty, it will have precedence over the secret.
   l1Url:

--- a/charts/op-proposer/ci/ct-values.yaml
+++ b/charts/op-proposer/ci/ct-values.yaml
@@ -1,6 +1,4 @@
 ---
-config:
-  l1Url: 
 secrets:
   # Private Key for the proposer. Either provide the secret name and key or the value directly. If value is not empty, it will have precedence over the secret.
   privateKey:

--- a/charts/op-proposer/ci/ct-values.yaml
+++ b/charts/op-proposer/ci/ct-values.yaml
@@ -2,6 +2,7 @@
 secrets:
   # Private Key for the proposer. Either provide the secret name and key or the value directly. If value is not empty, it will have precedence over the secret.
   privateKey:
+    value: 0x0000000000000000000000000000000000000000000000000000000000000001
     secretName: private-key-secret
     secretKey: privateKeyKey
   # L1 URL for the proposer. Either provide the secret name and key or the value directly. If value is not empty, it will have precedence over the secret.

--- a/charts/op-proposer/ci/ct-values.yaml
+++ b/charts/op-proposer/ci/ct-values.yaml
@@ -1,3 +1,11 @@
 ---
 config:
-  l1Url: "https://ethereum-holesky-rpc.publicnode.com"
+  l1Url: 
+secrets:
+  # Private Key for the proposer. Either provide the secret name and key or the value directly. If value is not empty, it will have precedence over the secret.
+  privateKey:
+    secretName: privateKeySecret
+    secretKey: privateKeyKey
+  # L1 URL for the proposer. Either provide the secret name and key or the value directly. If value is not empty, it will have precedence over the secret.
+  l1Url:
+    value: https://ethereum-holesky-rpc.publicnode.com

--- a/charts/op-proposer/templates/secret.yaml
+++ b/charts/op-proposer/templates/secret.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "op-proposer.labels" . | nindent 4 }}
 data:
   {{- with .Values.secrets.privateKey.value }}
-  privateKey: {{ . | b64enc | quote }}
+  privateKey: {{ toString . | b64enc | quote }}
   {{- end }}
   {{- with .Values.secrets.l1Url.value }}
   l1Url: {{ . | b64enc | quote }}

--- a/charts/op-proposer/templates/secret.yaml
+++ b/charts/op-proposer/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if or .Values.secrets.privateKey.value .Values.secrets.l1Url.value }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -5,4 +6,10 @@ metadata:
   labels:
     {{- include "op-proposer.labels" . | nindent 4 }}
 data:
-  privateKey: {{ .Values.config.privateKey | b64enc | quote }}
+  {{- with .Values.secrets.privateKey.value }}
+  privateKey: {{ . | b64enc | quote }}
+  {{- end }}
+  {{- with .Values.secrets.l1Url.value }}
+  l1Url: {{ . | b64enc | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/op-proposer/templates/statefulset.yaml
+++ b/charts/op-proposer/templates/statefulset.yaml
@@ -80,9 +80,9 @@ spec:
             --rollup-rpc={{ .Values.config.rollupRpc }} \
             --l2oo-address={{ .Values.config.L2OutputOracle }} \
             {{- if .Values.config.privateKey }}
-            --private-key=$(cat /secrets/privateKey) \
+            --private-key=$PRIVATE_KEY \
             {{- end }}
-            --l1-eth-rpc={{ .Values.config.l1Url }} \
+            --l1-eth-rpc=$L1_URL \
             {{- if .Values.config.metrics.enabled }}
             --metrics.enabled \
             --metrics.addr={{ .Values.config.metrics.addr }} \
@@ -91,7 +91,17 @@ spec:
             --log.level={{ .Values.config.logs.level }} \
             --log.format={{ .Values.config.logs.format }} \
             --log.color={{ .Values.config.logs.color }} \
-
+        env:
+        - name: PRIVATE_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ ternary (include "op-proposer.fullname" .) .Values.secrets.privateKey.secretName (not (empty .Values.secrets.privateKey.value)) }}
+              key: {{ ternary "privateKey" .Values.secrets.privateKey.secretKey (not (empty .Values.secrets.privateKey.value)) }}
+        - name: L1_URL
+          valueFrom:
+            secretKeyRef:
+              name: {{ ternary (include "op-proposer.fullname" .) .Values.secrets.l1Url.secretName (not (empty .Values.secrets.l1Url.value)) }}
+              key: {{ ternary "l1Url" .Values.secrets.l1Url.secretKey (not (empty .Values.secrets.l1Url.value)) }}
         ports:
         - name: rpc
           containerPort: {{ .Values.config.rpc.port }}
@@ -108,14 +118,13 @@ spec:
           {{- include "op-proposer.healthcheck" (list $ .Values.readinessProbe) | nindent 10 }}
         {{- end }}
         volumeMounts:
-        - name: secrets
-          mountPath: /secrets
+        - name: contracts
+          mountPath: /contracts
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
       {{- with .Values.sidecarContainers }}
         {{- tpl (toYaml . | nindent 6) $ }}
       {{- end }}
       volumes:
-      - name: secrets
-        secret:
-          secretName: {{ template "op-proposer.fullname" . }}
+      - name: contracts
+        emptyDir: {}

--- a/charts/op-proposer/values.yaml
+++ b/charts/op-proposer/values.yaml
@@ -124,14 +124,33 @@ nodeSelector: {}
 
 tolerations: []
 
+init:
+  contracts:
+    enabled: false
+    image:
+      repository: alpine
+      tag: 3.19
+      pullPolicy: IfNotPresent
+    url: ""
+
+secrets:
+  # Private Key for the proposer. Either provide the secret name and key or the value directly. If value is not empty, it will have precedence over the secret.
+  privateKey:
+    value: ""
+    secretName: ""
+    secretKey: ""
+  # L1 URL for the proposer. Either provide the secret name and key or the value directly. If value is not empty, it will have precedence over the secret.
+  l1Url:
+    value: ""
+    secretName: ""
+    secretKey: ""
+
 ## Main op-proposer config
 config:
   L2OutputOracle: ""                                                         # Address of the L2OutputOracle contract
   pollInterval: 12s                                                          # How frequently to poll L2 for new blocks
   rollupRpc: http://localhost:8547                                           # HTTP provider URL for the rollup node. A comma-separated list for multiple providers
   activeSecuencerCheckDuration: 2m0s                                         # How frequently to check if the sequencer is active (if multiple provided)
-  l1Url: ""                                                                  # HTTP provider URL for L1
-  privateKey: ""                                                             # Private key for the proposer
   logs:
     level: info                                                              # Log level
     format: json                                                             # Log format


### PR DESCRIPTION
Adding support to `op-proposer` chart to use existing secrets for `l1Url` and `privateKey`. Providing a value for these secrets on the chart take preference over providing an existing secret.