### PR TITLE
Submitting privateKey with cannonical env var (non using cmdflags)

### DIFF
--- a/charts/op-batcher/Chart.yaml
+++ b/charts/op-batcher/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 name: op-batcher
 apiVersion: v2
-version: 0.1.0
+version: 0.1.1
 description: Celo implementation for op-batcher client (Optimism Rollup)
 home: https://clabs.co
 sources:

--- a/charts/op-batcher/README.md
+++ b/charts/op-batcher/README.md
@@ -1,6 +1,6 @@
 # op-batcher
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.0](https://img.shields.io/badge/AppVersion-v1.0.0-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.0](https://img.shields.io/badge/AppVersion-v1.0.0-informational?style=flat-square)
 
 Celo implementation for op-batcher client (Optimism Rollup)
 

--- a/charts/op-batcher/templates/statefulset.yaml
+++ b/charts/op-batcher/templates/statefulset.yaml
@@ -112,7 +112,6 @@ spec:
             {{- end }}
             {{- end }}
             --l1-eth-rpc=$L1_URL \
-            --private-key=$PRIVATE_KEY \
             {{- if .Values.config.metrics.enabled }}
             --metrics.enabled \
             --metrics.addr={{ .Values.config.metrics.addr }} \
@@ -122,7 +121,7 @@ spec:
             --log.format={{ .Values.config.logs.format }} \
             --log.color={{ .Values.config.logs.color }}
         env:
-        - name: PRIVATE_KEY
+        - name: OP_BATCHER_PRIVATE_KEY
           valueFrom:
             secretKeyRef:
               name: {{ ternary (include "op-batcher.fullname" .) .Values.secrets.privateKey.secretName (not (empty .Values.secrets.privateKey.value)) }}

--- a/charts/op-proposer/Chart.yaml
+++ b/charts/op-proposer/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 name: op-proposer
 apiVersion: v2
-version: 0.1.0
+version: 0.1.1
 description: Celo implementation for op-proposer client (Optimism Rollup)
 home: https://clabs.co
 sources:

--- a/charts/op-proposer/README.md
+++ b/charts/op-proposer/README.md
@@ -1,6 +1,6 @@
 # op-proposer
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.0](https://img.shields.io/badge/AppVersion-v1.0.0-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.0](https://img.shields.io/badge/AppVersion-v1.0.0-informational?style=flat-square)
 
 Celo implementation for op-proposer client (Optimism Rollup)
 

--- a/charts/op-proposer/templates/statefulset.yaml
+++ b/charts/op-proposer/templates/statefulset.yaml
@@ -98,9 +98,6 @@ spec:
             --rpc.port={{ .Values.config.rpc.port }} \
             --rollup-rpc={{ .Values.config.rollupRpc }} \
             --l2oo-address=$L2OutputOracleProxy \
-            {{- if .Values.config.privateKey }}
-            --private-key=$PRIVATE_KEY \
-            {{- end }}
             --l1-eth-rpc=$L1_URL \
             {{- if .Values.config.metrics.enabled }}
             --metrics.enabled \
@@ -109,9 +106,9 @@ spec:
             {{- end }}
             --log.level={{ .Values.config.logs.level }} \
             --log.format={{ .Values.config.logs.format }} \
-            --log.color={{ .Values.config.logs.color }} \
+            --log.color={{ .Values.config.logs.color }}
         env:
-        - name: PRIVATE_KEY
+        - name: OP_PROPOSER_PRIVATE_KEY
           valueFrom:
             secretKeyRef:
               name: {{ ternary (include "op-proposer.fullname" .) .Values.secrets.privateKey.secretName (not (empty .Values.secrets.privateKey.value)) }}


### PR DESCRIPTION
Do not provide privateKey for op-proposer and op-batcher as cmdflag but using expected env var. This would avoid leaking privateKey by showing/sharing the cmd line.