### PR TITLE
Adding rpc service for op-bootnode

### DIFF
--- a/charts/op-bootnode/Chart.yaml
+++ b/charts/op-bootnode/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 name: op-bootnode
 apiVersion: v2
-version: 0.1.0
+version: 0.1.1
 description: Celo implementation for op-bootnode (Optimism Rollup)
 home: https://clabs.co
 sources:

--- a/charts/op-bootnode/README.md
+++ b/charts/op-bootnode/README.md
@@ -1,6 +1,6 @@
 # op-bootnode
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.0](https://img.shields.io/badge/AppVersion-v1.0.0-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.0](https://img.shields.io/badge/AppVersion-v1.0.0-informational?style=flat-square)
 
 Celo implementation for op-bootnode (Optimism Rollup)
 
@@ -31,7 +31,8 @@ Celo implementation for op-bootnode (Optimism Rollup)
 | config.p2p.advertise.ip | string | `""` |  |
 | config.p2p.disable | bool | `false` |  |
 | config.p2p.useHostPort | bool | `false` |  |
-| enableServiceLinks | bool | `true` |  |
+| config.rpc.useHostPort | bool | `false` |  |
+| enableServiceLinks | bool | `false` |  |
 | image.pullPolicy | string | `"Always"` |  |
 | image.repository | string | `"jcortejoso/op-bootnode"` |  |
 | image.tag | string | `"v1.7.4"` |  |
@@ -64,6 +65,14 @@ Celo implementation for op-bootnode (Optimism Rollup)
 | services.p2p.port | int | `9222` |  |
 | services.p2p.publishNotReadyAddresses | bool | `true` |  |
 | services.p2p.type | string | `"ClusterIP"` |  |
+| services.rpc.annotations | object | `{}` |  |
+| services.rpc.clusterIP | string | `""` |  |
+| services.rpc.enabled | bool | `false` |  |
+| services.rpc.loadBalancerIP | string | `""` |  |
+| services.rpc.nodePort | string | `""` |  |
+| services.rpc.port | int | `8545` |  |
+| services.rpc.publishNotReadyAddresses | bool | `true` |  |
+| services.rpc.type | string | `"ClusterIP"` |  |
 | terminationGracePeriodSeconds | int | `10` |  |
 | tolerations | list | `[]` |  |
 

--- a/charts/op-bootnode/templates/deployment.yaml
+++ b/charts/op-bootnode/templates/deployment.yaml
@@ -116,6 +116,12 @@ spec:
           {{- if .Values.config.p2p.useHostPort }}
           hostPort: 9222
           {{- end }}
+        - name: rpc-tcp  # raw "rpc" name can collision with expected op-bootnode env vars (i.e.: OP_BOOTNODE_RPC_PORT)
+          containerPort: 8545
+          protocol: TCP
+          {{- if .Values.config.rpc.useHostPort }}
+          hostPort: 8545
+          {{- end }}
       volumes:
       {{- if .Values.pvc.enabled }}
       - name: data

--- a/charts/op-bootnode/values.yaml
+++ b/charts/op-bootnode/values.yaml
@@ -5,7 +5,7 @@ image:
   tag: v1.7.4
   pullPolicy: Always
 
-enableServiceLinks: true
+enableServiceLinks: false
 terminationGracePeriodSeconds: 10
 imagePullSecrets: []
 podSecurityContext: {}
@@ -38,6 +38,17 @@ services:
     # nodePort: 9222
     annotations: {}
     publishNotReadyAddresses: true
+  rpc:
+    enabled: false
+    type: ClusterIP
+    loadBalancerIP: ""
+    clusterIP: ""
+    nodePort: ""
+    port: 8545
+    # it's better to set nodePort equal to .Values.config.node.p2p.port when the svc type is "NodePort"
+    # nodePort: 8545
+    annotations: {}
+    publishNotReadyAddresses: true
 
 pvc:
   enabled: true
@@ -63,6 +74,8 @@ config:
     disable: false                       # Disable the P2P network
     advertise:
       ip: ""                             # The IP address to advertise in Discv5, put into the ENR of the node. This may also be a hostname / domain name to resolve to an IP.
+    useHostPort: false
+  rpc:
     useHostPort: false
   logs:
     level: info


### PR DESCRIPTION
Adding the possibility of creating a service exposing RPC port for op-bootnode.