### PR TITLE
eigenda-proxy: fix deployment upgrades and metrics

### DIFF
--- a/charts/eigenda-proxy/Chart.yaml
+++ b/charts/eigenda-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 name: eigenda-proxy
 apiVersion: v2
-version: 0.1.0
+version: 0.1.1
 description: https://github.com/Layr-Labs/eigenda-proxy/tree/main
 home: https://clabs.co
 sources:

--- a/charts/eigenda-proxy/README.md
+++ b/charts/eigenda-proxy/README.md
@@ -1,6 +1,6 @@
 # eigenda-proxy
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.0](https://img.shields.io/badge/AppVersion-v1.0.0-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.0](https://img.shields.io/badge/AppVersion-v1.0.0-informational?style=flat-square)
 
 https://github.com/Layr-Labs/eigenda-proxy/tree/main
 

--- a/charts/eigenda-proxy/templates/deployment.yaml
+++ b/charts/eigenda-proxy/templates/deployment.yaml
@@ -8,13 +8,18 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       {{- include "eigenda-proxy.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: {{ quote .Values.services.metrics.port }}
+        prometheus.io/scrape: "true"
+      {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
@@ -88,16 +93,16 @@ spec:
             - |
               mkdir -p /data/resources
               exec /app/eigenda-proxy \
-                --addr 0.0.0.0 \
-                --port {{ .Values.services.api.port }} \
-                --eigenda-rpc {{ .Values.config.disperser.rpc }} \
-                --eigenda-status-query-timeout 45m \
-                --eigenda-g1-path /data/resources/g1.point \
-                --eigenda-g2-tau-path /data/resources/g2.point.powerOf2 \
-                --eigenda-disable-tls false \
-                --metrics.enabled \
-                --metrics.addr 0.0.0.0 \
-                --metrics.port {{ .Values.services.metrics.port }}
+                --addr=0.0.0.0 \
+                --port={{ .Values.services.api.port }} \
+                --eigenda-rpc={{ .Values.config.disperser.rpc }} \
+                --eigenda-status-query-timeout=45m \
+                --eigenda-g1-path=/data/resources/g1.point \
+                --eigenda-g2-tau-path=/data/resources/g2.point.powerOf2 \
+                --eigenda-disable-tls=false \
+                --metrics.enabled=true \
+                --metrics.addr=0.0.0.0 \
+                --metrics.port={{ .Values.services.metrics.port }}
           env:
             - name: EIGENDA_PROXY_SIGNER_PRIVATE_KEY_HEX
               value: {{ toString .Values.config.privateKey }}


### PR DESCRIPTION
Fix eigenda-proxy configuration to expose metrics and to being able of upgrade (PVC requires `Recreate` strategy)