### PR TITLE
Use the ip from services values for configuring the announce ip

### DIFF
--- a/charts/op-node/Chart.yaml
+++ b/charts/op-node/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 name: op-node
 apiVersion: v2
-version: 0.2.7
+version: 0.2.8
 description: Celo implementation for op-node consensus engine (Optimism Rollup)
 home: https://clabs.co
 sources:

--- a/charts/op-node/README.md
+++ b/charts/op-node/README.md
@@ -1,6 +1,6 @@
 # op-node
 
-![Version: 0.2.7](https://img.shields.io/badge/Version-0.2.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.0](https://img.shields.io/badge/AppVersion-v1.0.0-informational?style=flat-square)
+![Version: 0.2.8](https://img.shields.io/badge/Version-0.2.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.0](https://img.shields.io/badge/AppVersion-v1.0.0-informational?style=flat-square)
 
 Celo implementation for op-node consensus engine (Optimism Rollup)
 Initially based on [dysnix/charts/op-node](https://github.com/dysnix/charts/tree/main/dysnix/op-node).
@@ -38,7 +38,6 @@ Initially based on [dysnix/charts/op-node](https://github.com/dysnix/charts/tree
 | config.metrics.enabled | bool | `false` |  |
 | config.metrics.port | int | `7300` |  |
 | config.network | string | `"op-mainnet"` |  |
-| config.p2p.advertiseIPs | string | `""` |  |
 | config.p2p.bootnodes | list | `[]` |  |
 | config.p2p.keys | string | `""` |  |
 | config.p2p.nat | bool | `false` |  |

--- a/charts/op-node/templates/scripts/_split-config-parameters.tpl
+++ b/charts/op-node/templates/scripts/_split-config-parameters.tpl
@@ -25,12 +25,24 @@ if [ -f /secrets/sequencer.hex ]; then
 fi
 
 # Split the advertised addresses based on the comma and get the $RID-th key
-advertiseIp=$(echo "{{ .Values.config.p2p.advertiseIPs }}" | tr ',' '\n' | sed -n "$((RID + 1))p" | tr -d '\n')
-# Check if not empty
-if [ -n "$advertiseIp" ]; then
-  echo "Setting advertise address to $advertiseIp"
-  echo "$advertiseIp" > "$datadir/advertiseIP"
+loadBalancerIps="{{ join "," .Values.services.p2p.loadBalancerIPs }}"
+clusterIps="{{ join "," .Values.services.p2p.clusterIPs }}"
+# If the loadBalancerIPs are defined, use them
+if [ -n "$loadBalancerIps" ]; then
+  advertiseIp=$(echo "$loadBalancerIps" | tr ',' '\n' | sed -n "$((RID + 1))p")
+# If the clusterIPs are defined now, use them
+elif [ -n "$clusterIps" ]; then
+  advertiseIp=$(echo "$clusterIps" | tr ',' '\n' | sed -n "$((RID + 1))p")
+# If none of the above are defined, use pod's ip
+else
+  advertiseIp="$(hostname -i)"
 fi
+if [ -z "$advertiseIp" ]; then
+  echo "Could not determine advertise address"
+  exit 1
+fi
+echo "Setting advertise address to $advertiseIp"
+echo "$advertiseIp" > "$datadir/advertiseIP"
 
 # Get the L2 url
 l2Url=""

--- a/charts/op-node/values.yaml
+++ b/charts/op-node/values.yaml
@@ -227,7 +227,6 @@ config:
     port: 7300
   p2p:
     nat: false                         # use NAT to get external IP
-    advertiseIPs: ""                   # override announced p2p IP. Commas separated list of IPs
     port: 9222
     useHostPort: false                 # use hostPort for p2p traffic instead of dedicated k8s svc
     bootnodes: []                      # override bootnodes


### PR DESCRIPTION
Remove `announceIp` value duplication for op-node.

I've checking to implement automatic service detection but I've discarded because, if we want to set the same address (LoadBalancer or clusterIP) for p2p tcp and udp traffic, as they are decoupled in two different services, we need to set the ip value in the service template (i.e.: we cannot just let Kubernetes to automatically provide an ip, because in this case the ips would be different for tcp and udp services). Thus, the solution would require some external tooling that can create the IP and provide as value before the deployment (for ClusterIps) and/or use helm hooks, and seems easier and less problematic just leave this as a value to the chart.