### PR TITLE
Set affinity rule: place next to op-batcher

### DIFF
--- a/charts/eigenda-proxy/Chart.yaml
+++ b/charts/eigenda-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 name: eigenda-proxy
 apiVersion: v2
-version: 0.1.4
+version: 0.1.5
 description: https://github.com/Layr-Labs/eigenda-proxy/tree/main
 home: https://clabs.co
 sources:

--- a/charts/eigenda-proxy/README.md
+++ b/charts/eigenda-proxy/README.md
@@ -1,6 +1,6 @@
 # eigenda-proxy
 
-![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.0](https://img.shields.io/badge/AppVersion-v1.0.0-informational?style=flat-square)
+![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.0](https://img.shields.io/badge/AppVersion-v1.0.0-informational?style=flat-square)
 
 https://github.com/Layr-Labs/eigenda-proxy/tree/main
 
@@ -24,7 +24,11 @@ https://github.com/Layr-Labs/eigenda-proxy/tree/main
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| affinity | object | `{}` |  |
+| affinity.podAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.labelSelector.matchExpressions[0].key | string | `"app.kubernetes.io/name"` |  |
+| affinity.podAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.labelSelector.matchExpressions[0].operator | string | `"In"` |  |
+| affinity.podAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.labelSelector.matchExpressions[0].values[0] | string | `"op-batcher"` |  |
+| affinity.podAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.topologyKey | string | `"kubernetes.io/hostname"` |  |
+| affinity.podAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].weight | int | `100` |  |
 | autoscaling.enabled | bool | `false` |  |
 | autoscaling.maxReplicas | int | `100` |  |
 | autoscaling.minReplicas | int | `1` |  |
@@ -34,8 +38,8 @@ https://github.com/Layr-Labs/eigenda-proxy/tree/main
 | extraArgs | list | `[]` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"Always"` |  |
-| image.repository | string | `"jcortejoso/eigenda-proxy"` |  |
-| image.tag | string | `"latest"` |  |
+| image.repository | string | `"us-west1-docker.pkg.dev/devopsre/celo-blockchain-public/eigenda-proxy"` |  |
+| image.tag | string | `"v1.2.0"` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.className | string | `""` |  |

--- a/charts/eigenda-proxy/templates/deployment.yaml
+++ b/charts/eigenda-proxy/templates/deployment.yaml
@@ -34,8 +34,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "eigenda-proxy.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
       securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       initContainers:
         - name: download-srs
           image: alpine:latest

--- a/charts/eigenda-proxy/values.yaml
+++ b/charts/eigenda-proxy/values.yaml
@@ -6,10 +6,9 @@
 replicaCount: 1
 
 image:
-  repository: jcortejoso/eigenda-proxy
+  repository: us-west1-docker.pkg.dev/devopsre/celo-blockchain-public/eigenda-proxy
   pullPolicy: Always
-  # Overrides the image tag whose default is the chart appVersion.
-  tag: latest
+  tag: v1.2.0
 
 imagePullSecrets: []
 nameOverride: ""
@@ -105,7 +104,18 @@ nodeSelector: {}
 
 tolerations: []
 
-affinity: {}
+affinity:
+  podAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values:
+                  - op-batcher
+          topologyKey: "kubernetes.io/hostname"
 
 extraArgs: []
 


### PR DESCRIPTION
Adding affinity rule to schedule eigenda-proxy to same pod as running op-batcher. Rationale is that a restart of the batcher or proxy result in the restart of blob submission.