### PR TITLE
Fixes for nethermind multireplica

### DIFF
--- a/charts/nethermind/Chart.yaml
+++ b/charts/nethermind/Chart.yaml
@@ -3,7 +3,8 @@ apiVersion: v2
 name: nethermind
 description: .NET Core Ethereum client
 type: application
-version: 2.6.0.1
+# version: 2.6.0 # Version of stakewise/charts/nethermind
+version: 2.6.1
 appVersion: "v1.26.0"
 icon: https://storage.googleapis.com/stakewise-charts/stakewise.png
 keywords:

--- a/charts/nethermind/Chart.yaml
+++ b/charts/nethermind/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: nethermind
 description: .NET Core Ethereum client
 type: application
-version: 2.6.0
+version: 2.6.0.1
 appVersion: "v1.26.0"
 icon: https://storage.googleapis.com/stakewise-charts/stakewise.png
 keywords:

--- a/charts/nethermind/README.md
+++ b/charts/nethermind/README.md
@@ -1,6 +1,6 @@
 # nethermind
 
-![Version: 2.6.0](https://img.shields.io/badge/Version-2.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.26.0](https://img.shields.io/badge/AppVersion-v1.26.0-informational?style=flat-square)
+![Version: 2.6.1](https://img.shields.io/badge/Version-2.6.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.26.0](https://img.shields.io/badge/AppVersion-v1.26.0-informational?style=flat-square)
 
 .NET Core Ethereum client
 Initially based on [stakewise/helm-charts/nethermind](https://github.com/stakewise/helm-charts/tree/main/charts/nethermind).
@@ -45,7 +45,7 @@ Initially based on [stakewise/helm-charts/nethermind](https://github.com/stakewi
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.registry | string | `"docker.io"` |  |
 | image.repository | string | `"nethermind/nethermind"` |  |
-| image.tag | string | `"1.26.0"` |  |
+| image.tag | string | `"1.27.0"` |  |
 | imagePullSecrets | list | `[]` |  |
 | initChownData | bool | `true` |  |
 | initImage.pullPolicy | string | `"IfNotPresent"` |  |

--- a/charts/nethermind/templates/service.yaml
+++ b/charts/nethermind/templates/service.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: Service
 metadata:
@@ -41,3 +40,52 @@ spec:
   {{- end }}
   selector:
     {{- include "common.labels.matchLabels" . | nindent 4 }}
+
+{{- range $i, $e := until (int .Values.global.replicaCount) }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "common.names.fullname" $ }}-{{ $i }}
+  labels:
+    {{- include "common.labels.standard" $ | nindent 4 }}
+    pod: "{{ include "common.names.fullname" $ }}-{{ $i }}"
+spec:
+  type: {{ $.Values.service.type }}
+{{- if $.Values.svcHeadless }}
+  clusterIP: None
+{{- end }}
+{{- if $.Values.sessionAffinity.enabled }}
+  sessionAffinity: ClientIP
+  sessionAffinityConfig:
+    clientIP:
+      timeoutSeconds: {{ $.Values.sessionAffinity.timeoutSeconds }}
+{{- end }}
+  ports:
+  {{- if $.Values.jsonrpc.enabled }}
+    - port: {{ $.Values.jsonrpc.ports.rest }}
+      targetPort: json-rest
+      protocol: TCP
+      name: json-rest
+    - port: {{ $.Values.jsonrpc.ports.websocket }}
+      targetPort: json-ws
+      protocol: TCP
+      name: json-ws
+  {{- end }}
+  {{- if $.Values.global.JWTSecret }}
+    - port: {{ $.Values.jsonrpc.engine.port }}
+      targetPort: engine
+      protocol: TCP
+      name: engine
+  {{- end }}
+  {{- if $.Values.global.metrics.enabled }}
+    - port: {{ $.Values.metrics.port }}
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+  {{- end }}
+  selector:
+    {{- include "common.labels.matchLabels" $ | nindent 4 }}
+    statefulset.kubernetes.io/pod-name: "{{ include "common.names.fullname" $ }}-{{ $i }}"
+
+{{- end }}

--- a/charts/nethermind/values.yaml
+++ b/charts/nethermind/values.yaml
@@ -99,7 +99,7 @@ image:
   repository: nethermind/nethermind
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "1.26.0"
+  tag: "1.27.0"
 
 ## Credentials to fetch images from private registry
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/


### PR DESCRIPTION
- Added pod services (required for `engine` endpoint, communication with prysm/consensus engine).
- Bumped nethermind default version
