### PR TITLE
Refactor cel2-migration-tool chart 

### DIFF
--- a/charts/cel2-migration-tool/Chart.yaml
+++ b/charts/cel2-migration-tool/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 name: cel2-migration-tool
 apiVersion: v2
-version: 0.1.3
+version: 0.1.4
 description: Node migration tool for Cel2 network
 home: https://clabs.co
 sources:

--- a/charts/cel2-migration-tool/README.md
+++ b/charts/cel2-migration-tool/README.md
@@ -23,7 +23,7 @@ Node migration tool for Cel2 network
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| cel2NetworkName | string | `"myNetwork"` |  |
+| cel2NetworkName | string | `"myNetwork"` | Reference name for the tar.zstd file |
 | compressAndUpload.image.pullPolicy | string | `"IfNotPresent"` |  |
 | compressAndUpload.image.repository | string | `"alpine"` |  |
 | compressAndUpload.image.tag | float | `3.19` |  |
@@ -33,19 +33,19 @@ Node migration tool for Cel2 network
 | downloadDeps.image.pullPolicy | string | `"IfNotPresent"` |  |
 | downloadDeps.image.repository | string | `"alpine"` |  |
 | downloadDeps.image.tag | float | `3.19` |  |
-| gcsBucket | string | `"cel2-node-files/"` |  |
-| l1Url | string | `"https://ethereum-holesky-rpc.publicnode.com"` |  |
+| gcsBucket | string | `"cel2-node-files/"` | GCS bucket to store the tar.zstd file |
+| l1Url | string | `"https://ethereum-holesky-rpc.publicnode.com"` | RPC URL for L1 blockchain |
 | migrationTool.config.batchSize | int | `5000` |  |
 | migrationTool.config.memoryLimit | int | `20000` |  |
 | migrationTool.extraArgs | list | `[]` |  |
 | migrationTool.image.pullPolicy | string | `"Always"` |  |
 | migrationTool.image.repository | string | `"us-west1-docker.pkg.dev/devopsre/dev-images/cel2-migration-tool"` |  |
 | migrationTool.image.tag | string | `"8bdebc03a0526b6474dfba468884116ee1366907"` |  |
-| migrationTool.pauseOnCompletion | bool | `false` |  |
+| migrationTool.pauseOnCompletion | bool | `false` | Run `tail -f /dev/null` to keep the migration job alive after completion |
 | migrationTool.resources | object | `{}` |  |
 | pvc.input | string | `"myNetwork-input"` |  |
 | pvc.output | string | `"myNetwork-output"` |  |
-| pvc.useOutputAsInput | bool | `true` |  |
+| pvc.useOutputAsInput | bool | `true` | Only one PVC required. This operation is not idempotent |
 | schedule | string | `"0 0 30 2 0"` |  |
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `true` |  |

--- a/charts/cel2-migration-tool/README.md
+++ b/charts/cel2-migration-tool/README.md
@@ -38,7 +38,7 @@ Node migration tool for Cel2 network
 | migrationTool.resources | object | `{}` |  |
 | pvc.input | string | `"myNetwork-input"` |  |
 | pvc.output | string | `"myNetwork-output"` |  |
-| pvc.useOuptutAsInput | bool | `true` |  |
+| pvc.useOutputAsInput | bool | `true` |  |
 | schedule | string | `"0 0 30 2 0"` |  |
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `true` |  |

--- a/charts/cel2-migration-tool/README.md
+++ b/charts/cel2-migration-tool/README.md
@@ -41,6 +41,7 @@ Node migration tool for Cel2 network
 | migrationTool.image.pullPolicy | string | `"Always"` |  |
 | migrationTool.image.repository | string | `"us-west1-docker.pkg.dev/devopsre/dev-images/cel2-migration-tool"` |  |
 | migrationTool.image.tag | string | `"8bdebc03a0526b6474dfba468884116ee1366907"` |  |
+| migrationTool.pauseOnCompletion | bool | `false` |  |
 | migrationTool.resources | object | `{}` |  |
 | pvc.input | string | `"myNetwork-input"` |  |
 | pvc.output | string | `"myNetwork-output"` |  |

--- a/charts/cel2-migration-tool/README.md
+++ b/charts/cel2-migration-tool/README.md
@@ -1,6 +1,6 @@
 # cel2-migration-tool
 
-![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.0](https://img.shields.io/badge/AppVersion-v1.0.0-informational?style=flat-square)
+![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.0](https://img.shields.io/badge/AppVersion-v1.0.0-informational?style=flat-square)
 
 Node migration tool for Cel2 network
 
@@ -24,9 +24,15 @@ Node migration tool for Cel2 network
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | cel2NetworkName | string | `"myNetwork"` |  |
+| compressAndUpload.image.pullPolicy | string | `"IfNotPresent"` |  |
+| compressAndUpload.image.repository | string | `"alpine"` |  |
+| compressAndUpload.image.tag | float | `3.19` |  |
 | download.config | string | `"https://storage.googleapis.com/cel2-rollup-files/jctestnet/config.json"` |  |
 | download.deploymentL1 | string | `"https://storage.googleapis.com/cel2-rollup-files/jctestnet/deployment-l1.json"` |  |
 | download.l2Allocs | string | `"https://storage.googleapis.com/cel2-rollup-files/jctestnet/l2-allocs.json"` |  |
+| downloadDeps.image.pullPolicy | string | `"IfNotPresent"` |  |
+| downloadDeps.image.repository | string | `"alpine"` |  |
+| downloadDeps.image.tag | float | `3.19` |  |
 | gcsBucket | string | `"cel2-node-files/"` |  |
 | l1Url | string | `"https://ethereum-holesky-rpc.publicnode.com"` |  |
 | migrationTool.config.batchSize | int | `5000` |  |

--- a/charts/cel2-migration-tool/templates/cronjob.yaml
+++ b/charts/cel2-migration-tool/templates/cronjob.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ .Release.Name }}
   labels:
     {{- include "cel2-migration-tool.labels" . | nindent 4 }}
-    component: blockscout-metadata-crawler
+    component: cel2-migration-tool
 spec:
   schedule: "{{ .Values.schedule }}"
   concurrencyPolicy: Forbid
@@ -19,8 +19,8 @@ spec:
           serviceAccountName: {{ include "cel2-migration-tool.serviceAccountName" . }}
           initContainers:
           - name: download-dependencies
-            image: alpine:3.19
-            imagePullPolicy: IfNotPresent
+            image: {{ .Values.downloadDeps.image.repository }}:{{ .Values.downloadDeps.image.tag }}
+            imagePullPolicy: {{ .Values.downloadDeps.image.pullPolicy }}
             command:
             - /bin/sh
             - -c
@@ -44,7 +44,7 @@ spec:
             {{- end }}
           - name: migration
             image: {{ .Values.migrationTool.image.repository }}:{{ .Values.migrationTool.image.tag }}
-            imagePullPolicy: Always
+            imagePullPolicy: {{ .Values.migrationTool.image.pullPolicy }}
             command:
             - /bin/sh
             - -c

--- a/charts/cel2-migration-tool/templates/cronjob.yaml
+++ b/charts/cel2-migration-tool/templates/cronjob.yaml
@@ -26,15 +26,7 @@ spec:
             - -c
             args:
             - |
-              mkdir -p /output/config
-              wget -O /output/config/config.json {{ .Values.download.config }}
-              wget -O /output/config/deployment-l1.json {{ .Values.download.deploymentL1 }}
-              wget -O /output/config/l2-allocs.json {{ .Values.download.l2Allocs }}
-              {{- if not .Values.pvc.useOutputAsInput }}
-              apk add -U rsync
-              echo "Copying chaindata to /output/celo/chaindata"
-              rsync -ah --progress /input/celo /output/
-              {{- end }}
+              {{- include (print $.Template.BasePath "/scripts/_download-deps.tpl") . | nindent 14 }}
             volumeMounts:
             - mountPath: /output
               name: output
@@ -50,26 +42,7 @@ spec:
             - -c
             args:
             - |
-              echo "Starting chain operations"
-
-              time celo-migrate full \
-                --deploy-config /output/config/config.json \
-                --l1-deployments /output/config/deployment-l1.json \
-                --l2-allocs /output/config/l2-allocs.json \
-                --l1-rpc {{ .Values.l1Url | quote }} \
-                --outfile.rollup-config /output/config/rollup.json \
-                --old-db /output/celo/chaindata \
-                --new-db /output/celo/chaindata_migrated \
-                --memory-limit {{ .Values.migrationTool.config.memoryLimit }} \
-                --batch-size {{ .Values.migrationTool.config.batchSize }} \
-                {{- range .Values.migrationTool.extraArgs }}
-                {{ tpl (.) $ }} \
-                {{- end }}
-
-              rm -rf /output/celo/chaindata
-              mv /output/celo/chaindata_migrated /output/celo/chaindata
-              mv /output/celo /output/geth
-              tail -f /dev/null
+              {{- include (print $.Template.BasePath "/scripts/_migration.tpl") . | nindent 14 }}
             {{- with .Values.migrationTool.resources }}
             resources:
               {{- toYaml . | nindent 12 }}
@@ -79,33 +52,14 @@ spec:
               name: output
           containers:
           - name: compress-and-upload
-            image: alpine:3.19
-            imagePullPolicy: IfNotPresent
+            image: {{ .Values.compressAndUpload.image.repository }}:{{ .Values.compressAndUpload.image.tag }}
+            imagePullPolicy: {{ .Values.compressAndUpload.image.pullPolicy }}
             command:
             - /bin/sh
             - -c
             args:
             - |
-              # Install dependencies
-              apk add --no-cache tar zstd curl bash python3 pv
-
-              # Install gcloud cli
-              curl -sSL https://sdk.cloud.google.com | bash -s -- --disable-prompts
-              source /root/google-cloud-sdk/path.bash.inc
-              /root/google-cloud-sdk/bin/gcloud components install alpha -q
-
-              # Uplaod rollup config
-              /root/google-cloud-sdk/bin/gcloud alpha storage cp /output/config/rollup-config.json gs://{{ .Values.gcsBucket | trimPrefix "gs://" | trimSuffix "/" }}/{{ .Values.cel2NetworkName }}-rollup.json
-
-              # Delete jwt and nodekey
-              rm -f /output/geth/nodekey /output/geth/jwtsecret
-
-              # Compress the node data using zstd
-              echo "Compressing the node data. Progress is referenced to the uncompressed size, so you can expect it won't reach 100%"
-              cd /output && tar -I 'zstd -T0' -cf - geth | pv -s $(du -sb /output/geth | awk '{print $1}') > {{ .Values.cel2NetworkName }}-cel2.tar.zstd
-
-              # Upload the compressed data to the bucket
-              /root/google-cloud-sdk/bin/gcloud alpha storage cp /output/{{ .Values.cel2NetworkName }}-cel2.tar.zstd gs://{{ .Values.gcsBucket | trimPrefix "gs://" | trimSuffix "/" }}/{{ .Values.cel2NetworkName }}-cel2.tar.zstd
+              {{- include (print $.Template.BasePath "/scripts/_compress-and-upload.tpl") . | nindent 14 }}
             volumeMounts:
             - mountPath: /output
               name: output

--- a/charts/cel2-migration-tool/templates/cronjob.yaml
+++ b/charts/cel2-migration-tool/templates/cronjob.yaml
@@ -30,7 +30,7 @@ spec:
               wget -O /output/config/config.json {{ .Values.download.config }}
               wget -O /output/config/deployment-l1.json {{ .Values.download.deploymentL1 }}
               wget -O /output/config/l2-allocs.json {{ .Values.download.l2Allocs }}
-              {{- if not .Values.pvc.useOuptutAsInput }}
+              {{- if not .Values.pvc.useOutputAsInput }}
               apk add -U rsync
               echo "Copying chaindata to /output/celo/chaindata"
               rsync -ah --progress /input/celo /output/
@@ -38,7 +38,7 @@ spec:
             volumeMounts:
             - mountPath: /output
               name: output
-            {{- if not .Values.pvc.useOuptutAsInput }}
+            {{- if not .Values.pvc.useOutputAsInput }}
             - mountPath: /input
               name: input
             {{- end }}
@@ -110,7 +110,7 @@ spec:
             - mountPath: /output
               name: output
           volumes:
-            {{- if not .Values.pvc.useOuptutAsInput }}
+            {{- if not .Values.pvc.useOutputAsInput }}
             - name: input
               persistentVolumeClaim:
                 claimName: {{ .Values.pvc.input }}

--- a/charts/cel2-migration-tool/templates/scripts/_compress-and-upload.tpl
+++ b/charts/cel2-migration-tool/templates/scripts/_compress-and-upload.tpl
@@ -1,0 +1,20 @@
+# Install dependencies
+apk add --no-cache tar zstd curl bash python3 pv
+
+# Install gcloud cli
+curl -sSL https://sdk.cloud.google.com | bash -s -- --disable-prompts
+source /root/google-cloud-sdk/path.bash.inc
+/root/google-cloud-sdk/bin/gcloud components install alpha -q
+
+# Uplaod rollup config
+/root/google-cloud-sdk/bin/gcloud alpha storage cp /output/config/rollup-config.json gs://{{ .Values.gcsBucket | trimPrefix "gs://" | trimSuffix "/" }}/{{ .Values.cel2NetworkName }}-rollup.json
+
+# Delete jwt and nodekey
+rm -f /output/geth/nodekey /output/geth/jwtsecret
+
+# Compress the node data using zstd
+echo "Compressing the node data. Progress is referenced to the uncompressed size, so you can expect it won't reach 100%"
+cd /output && tar -I 'zstd -T0' -cf - geth | pv -s $(du -sb /output/geth | awk '{print $1}') > {{ .Values.cel2NetworkName }}-cel2.tar.zstd
+
+# Upload the compressed data to the bucket
+/root/google-cloud-sdk/bin/gcloud alpha storage cp /output/{{ .Values.cel2NetworkName }}-cel2.tar.zstd gs://{{ .Values.gcsBucket | trimPrefix "gs://" | trimSuffix "/" }}/{{ .Values.cel2NetworkName }}-cel2.tar.zstd

--- a/charts/cel2-migration-tool/templates/scripts/_download-deps.tpl
+++ b/charts/cel2-migration-tool/templates/scripts/_download-deps.tpl
@@ -1,0 +1,9 @@
+mkdir -p /output/config
+wget -O /output/config/config.json {{ .Values.download.config }}
+wget -O /output/config/deployment-l1.json {{ .Values.download.deploymentL1 }}
+wget -O /output/config/l2-allocs.json {{ .Values.download.l2Allocs }}
+{{- if not .Values.pvc.useOutputAsInput }}
+apk add -U rsync
+echo "Copying chaindata to /output/celo/chaindata"
+rsync -ah --progress /input/celo /output/
+{{- end }}

--- a/charts/cel2-migration-tool/templates/scripts/_migration.tpl
+++ b/charts/cel2-migration-tool/templates/scripts/_migration.tpl
@@ -1,15 +1,15 @@
 echo "Starting chain operations"
 
 time celo-migrate full \
---deploy-config /output/config/config.json \
---l1-deployments /output/config/deployment-l1.json \
---l2-allocs /output/config/l2-allocs.json \
---l1-rpc {{ .Values.l1Url | quote }} \
---outfile.rollup-config /output/config/rollup.json \
---old-db /output/celo/chaindata \
---new-db /output/celo/chaindata_migrated \
---memory-limit {{ .Values.migrationTool.config.memoryLimit }} \
---batch-size {{ .Values.migrationTool.config.batchSize }} \
+  --deploy-config /output/config/config.json \
+  --l1-deployments /output/config/deployment-l1.json \
+  --l2-allocs /output/config/l2-allocs.json \
+  --l1-rpc {{ .Values.l1Url | quote }} \
+  --outfile.rollup-config /output/config/rollup.json \
+  --old-db /output/celo/chaindata \
+  --new-db /output/celo/chaindata_migrated \
+  --memory-limit {{ .Values.migrationTool.config.memoryLimit }} \
+  --batch-size {{ .Values.migrationTool.config.batchSize }} \
 {{- range .Values.migrationTool.extraArgs }}
 {{ tpl (.) $ }} \
 {{- end }}

--- a/charts/cel2-migration-tool/templates/scripts/_migration.tpl
+++ b/charts/cel2-migration-tool/templates/scripts/_migration.tpl
@@ -1,0 +1,20 @@
+echo "Starting chain operations"
+
+time celo-migrate full \
+--deploy-config /output/config/config.json \
+--l1-deployments /output/config/deployment-l1.json \
+--l2-allocs /output/config/l2-allocs.json \
+--l1-rpc {{ .Values.l1Url | quote }} \
+--outfile.rollup-config /output/config/rollup.json \
+--old-db /output/celo/chaindata \
+--new-db /output/celo/chaindata_migrated \
+--memory-limit {{ .Values.migrationTool.config.memoryLimit }} \
+--batch-size {{ .Values.migrationTool.config.batchSize }} \
+{{- range .Values.migrationTool.extraArgs }}
+{{ tpl (.) $ }} \
+{{- end }}
+
+rm -rf /output/celo/chaindata
+mv /output/celo/chaindata_migrated /output/celo/chaindata
+mv /output/celo /output/geth
+tail -f /dev/null

--- a/charts/cel2-migration-tool/templates/scripts/_migration.tpl
+++ b/charts/cel2-migration-tool/templates/scripts/_migration.tpl
@@ -9,12 +9,15 @@ time celo-migrate full \
   --old-db /output/celo/chaindata \
   --new-db /output/celo/chaindata_migrated \
   --memory-limit {{ .Values.migrationTool.config.memoryLimit }} \
-  --batch-size {{ .Values.migrationTool.config.batchSize }} \
-{{- range .Values.migrationTool.extraArgs }}
-{{ tpl (.) $ }} \
-{{- end }}
+  --batch-size {{ .Values.migrationTool.config.batchSize }}{{ if .Values.migrationTool.extraArgs }} \{{ end }}
+  {{- $length := len .Values.migrationTool.extraArgs }}
+  {{- range $index, $value := .Values.migrationTool.extraArgs }}
+  {{ tpl $value $ }}{{ if lt $index (sub $length 1) }} \{{ end }}
+  {{- end }}
 
 rm -rf /output/celo/chaindata
 mv /output/celo/chaindata_migrated /output/celo/chaindata
 mv /output/celo /output/geth
+{{ if .Values.migrationTool.pauseOnCompletion }}
 tail -f /dev/null
+{{- end }}

--- a/charts/cel2-migration-tool/values.yaml
+++ b/charts/cel2-migration-tool/values.yaml
@@ -19,6 +19,11 @@ downloadDeps:
     repository: alpine
     tag: 3.19
     pullPolicy: IfNotPresent
+compressAndUpload:
+  image:
+    repository: alpine
+    tag: 3.19
+    pullPolicy: IfNotPresent
 migrationTool:
   image:
     repository: us-west1-docker.pkg.dev/devopsre/dev-images/cel2-migration-tool

--- a/charts/cel2-migration-tool/values.yaml
+++ b/charts/cel2-migration-tool/values.yaml
@@ -34,3 +34,4 @@ migrationTool:
     batchSize: 5000
     memoryLimit: 20000
   extraArgs: []
+  pauseOnCompletion: false # Run `tail -f /dev/null` to keep the migration job alive after completion

--- a/charts/cel2-migration-tool/values.yaml
+++ b/charts/cel2-migration-tool/values.yaml
@@ -34,4 +34,4 @@ migrationTool:
     batchSize: 5000
     memoryLimit: 20000
   extraArgs: []
-  pauseOnCompletion: false # Run `tail -f /dev/null` to keep the migration job alive after completion
+  pauseOnCompletion: false  # Run `tail -f /dev/null` to keep the migration job alive after completion

--- a/charts/cel2-migration-tool/values.yaml
+++ b/charts/cel2-migration-tool/values.yaml
@@ -16,7 +16,7 @@ download:
 pvc:
   input: myNetwork-input
   # -- Only one PVC required. This operation is not idempotent
-  useOutputAsInput: true  
+  useOutputAsInput: true
   output: myNetwork-output
 downloadDeps:
   image:
@@ -39,4 +39,4 @@ migrationTool:
     memoryLimit: 20000
   extraArgs: []
   # -- Run `tail -f /dev/null` to keep the migration job alive after completion
-  pauseOnCompletion: false  
+  pauseOnCompletion: false

--- a/charts/cel2-migration-tool/values.yaml
+++ b/charts/cel2-migration-tool/values.yaml
@@ -12,7 +12,7 @@ download:
   l2Allocs: https://storage.googleapis.com/cel2-rollup-files/jctestnet/l2-allocs.json
 pvc:
   input: myNetwork-input
-  useOuptutAsInput: true  # Only one PVC required. This operation is not idempotent
+  useOutputAsInput: true  # Only one PVC required. This operation is not idempotent
   output: myNetwork-output
 downloadDeps:
   image:

--- a/charts/cel2-migration-tool/values.yaml
+++ b/charts/cel2-migration-tool/values.yaml
@@ -3,8 +3,11 @@ serviceAccount:
   create: true
   annotations: {}
 schedule: "0 0 30 2 0"
-cel2NetworkName: myNetwork  # Reference name for the tar.zstd file
-gcsBucket: cel2-node-files/  # GCS bucket to store the tar.zstd file
+# -- Reference name for the tar.zstd file
+cel2NetworkName: myNetwork
+# -- GCS bucket to store the tar.zstd file
+gcsBucket: cel2-node-files/
+# -- RPC URL for L1 blockchain
 l1Url: https://ethereum-holesky-rpc.publicnode.com
 download:
   config: https://storage.googleapis.com/cel2-rollup-files/jctestnet/config.json
@@ -12,7 +15,8 @@ download:
   l2Allocs: https://storage.googleapis.com/cel2-rollup-files/jctestnet/l2-allocs.json
 pvc:
   input: myNetwork-input
-  useOutputAsInput: true  # Only one PVC required. This operation is not idempotent
+  # -- Only one PVC required. This operation is not idempotent
+  useOutputAsInput: true  
   output: myNetwork-output
 downloadDeps:
   image:
@@ -34,4 +38,5 @@ migrationTool:
     batchSize: 5000
     memoryLimit: 20000
   extraArgs: []
-  pauseOnCompletion: false  # Run `tail -f /dev/null` to keep the migration job alive after completion
+  # -- Run `tail -f /dev/null` to keep the migration job alive after completion
+  pauseOnCompletion: false  

--- a/charts/cel2-migration-tool/values.yaml
+++ b/charts/cel2-migration-tool/values.yaml
@@ -14,6 +14,11 @@ pvc:
   input: myNetwork-input
   useOuptutAsInput: true  # Only one PVC required. This operation is not idempotent
   output: myNetwork-output
+downloadDeps:
+  image:
+    repository: alpine
+    tag: 3.19
+    pullPolicy: IfNotPresent
 migrationTool:
   image:
     repository: us-west1-docker.pkg.dev/devopsre/dev-images/cel2-migration-tool


### PR DESCRIPTION
This PR is an attempt at learning to refactor helm charts in a way that we are comfortable with. Starting with this repo as it is self contained and a one off job that is not regularly launched. Comments and suggestions on style and approach are appreciated

The main changes are

* using consistent values references for `alpine` containers
* import scripts via from discrete files in the `/templates/scripts` dir

also

* fix some typos

## Todo:

* identify secret values and replace with templating + k8s secrets
    * ~are rpc urls secrets?~

## Discussion points

* is this way of handling script files something we want to have across all charts?

## Testing

* `helm diff` shows no changes except for typos and whitespace when run with values from an alfajores release