### PR TITLE
Refactor op-tx-overload

### DIFF
--- a/charts/op-tx-overload/Chart.yaml
+++ b/charts/op-tx-overload/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: op-tx-overload
 description: Generate load on Optimism Bedrock using transactions with random calldata.
 type: application
-version: 0.1.1
+version: 0.2.0
 appVersion: "test"
 sources:
   - https://github.com/celo-org/tx-overload

--- a/charts/op-tx-overload/README.md
+++ b/charts/op-tx-overload/README.md
@@ -1,6 +1,6 @@
 # op-tx-overload
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: test](https://img.shields.io/badge/AppVersion-test-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: test](https://img.shields.io/badge/AppVersion-test-informational?style=flat-square)
 
 Generate load on Optimism Bedrock using transactions with random calldata.
 
@@ -20,8 +20,12 @@ Generate load on Optimism Bedrock using transactions with random calldata.
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Kubernetes pod affinity |
-| args | list | `[]` | Args for the deployment. |
-| command | list | `[]` | Command for the deployment. "./tx-overload" if empty. |
+| config.dataRate | int | `1000` |  |
+| config.ethRpc | string | `"http://op-geth-sequencer-shared-rpc:8545"` |  |
+| config.logFormat | string | `"json"` |  |
+| config.numDistributors | int | `4` |  |
+| config.txMode | string | `"random"` |  |
+| extraArgs | object | `{}` | Args for the deployment. |
 | fullnameOverride | string | `""` | Chart full name override |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pullpolicy |
 | image.repository | string | `"us-west1-docker.pkg.dev/devopsre/dev-images/tx-overload"` | Image repository |

--- a/charts/op-tx-overload/templates/statefulset.yaml
+++ b/charts/op-tx-overload/templates/statefulset.yaml
@@ -1,20 +1,23 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ include "op-tx-overload.fullname" . }}
   labels:
     {{- include "op-tx-overload.labels" . | nindent 4 }}
 spec:
+  serviceName: {{ include "op-tx-overload.fullname" . }}
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
       {{- include "op-tx-overload.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- if .Values.metrics.enabled }}
+        prometheus.io/path: /metrics
+        prometheus.io/port: "7300"
+        prometheus.io/scrape: "true"
+        {{- end }}
       labels:
         {{- include "op-tx-overload.labels" . | nindent 8 }}
         {{- with .Values.podLabels }}
@@ -34,19 +37,25 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- with .Values.command }}
           command:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          {{- if or (.Values.args) (.Values.metrics.enabled) }}
+          - /bin/sh
+          - -c
           args:
-          {{- with .Values.args }}
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          {{- if .Values.metrics.enabled }}
-            - --metrics.enabled
-          {{- end }}
-          {{- end }}
+          - |
+            RID=$(echo $HOSTNAME | sed 's/{{ .Release.Name }}-//')
+            STARTING_INDEX=$((RID * {{ .Values.config.numDistributors }}))
+            /tx-overload.bin \
+              --eth-rpc={{ .Values.config.ethRpc }} \
+              --tx-mode={{ .Values.config.txMode }} \
+              --num-distributors={{ .Values.config.numDistributors }} \
+              --data-rate={{ .Values.config.dataRate }} \
+              --log.format={{ .Values.config.logFormat }} \
+              {{- if .Values.metrics.enabled }}
+              --metrics.enabled \
+              {{- end }}
+              {{- with .Values.extraArgs }}
+              {{- toYaml . | nindent 14 }} \
+              {{- end }}
           {{- if .Values.metrics.enabled }}
           ports:
             - name: metrics
@@ -79,3 +88,6 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+  volumeClaimTemplates: []
+  updateStrategy:
+    type: RollingUpdate

--- a/charts/op-tx-overload/values.yaml
+++ b/charts/op-tx-overload/values.yaml
@@ -10,20 +10,15 @@ fullnameOverride: ""
 # -- Number of deployment replicas
 replicaCount: 1
 
-# -- Command for the deployment. "./tx-overload" if empty.
-command: []
-  # - |
-  #   echo "Done testing"
-  #   tail -f /dev/null
+config:
+  ethRpc: http://op-geth-sequencer-shared-rpc:8545
+  txMode: random
+  numDistributors: 4
+  dataRate: 1000
+  logFormat: json
 
 # -- Args for the deployment.
-args: []
-  # - --eth-rpc
-  # - http://op-geth:8545
-  # - --num-distributors
-  # - "1"
-  # - --data-rate
-  # - "1000"
+extraArgs: {}
 
 # -- Env Vars. mounted from a secret
 secretEnv: {}


### PR DESCRIPTION
Using statefulset to have replicas indexed.
Using static command/args to ease with deployment and config (and be able to use `RID` in the command).