### PR TITLE
Included option to use smaller KZG files

### DIFF
--- a/charts/eigenda-proxy/Chart.yaml
+++ b/charts/eigenda-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 name: eigenda-proxy
 apiVersion: v2
-version: 0.3.0
+version: 0.3.1
 description: Helm chart deploying Layr-Labs eigenda-proxy
 home: https://clabs.co
 sources:

--- a/charts/eigenda-proxy/README.md
+++ b/charts/eigenda-proxy/README.md
@@ -38,6 +38,7 @@ Helm chart deploying Layr-Labs eigenda-proxy
 | config.eth.confirmationDepth | int | `1` |  |
 | config.eth.rpc | string | `"https://ethereum-holesky-rpc.publicnode.com"` |  |
 | config.eth.serviceManagerAddr | string | `"0xD4A7E1Bd8015057293f0D0A557088c286942e84b"` |  |
+| config.maxBlobLength | string | `"32MiB"` |  |
 | config.privateKey.value | string | `""` |  |
 | config.routing.cacheTargets | string | `""` |  |
 | config.s3.accessKeyId | string | `""` |  |

--- a/charts/eigenda-proxy/README.md
+++ b/charts/eigenda-proxy/README.md
@@ -1,6 +1,6 @@
 # eigenda-proxy
 
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.0](https://img.shields.io/badge/AppVersion-v1.0.0-informational?style=flat-square)
+![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.0](https://img.shields.io/badge/AppVersion-v1.0.0-informational?style=flat-square)
 
 Helm chart deploying Layr-Labs eigenda-proxy
 
@@ -33,6 +33,7 @@ Helm chart deploying Layr-Labs eigenda-proxy
 | autoscaling.maxReplicas | int | `100` |  |
 | autoscaling.minReplicas | int | `1` |  |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
+| config.bigKZGFiles | bool | `false` |  |
 | config.disperser.rpc | string | `"disperser-holesky.eigenda.xyz:443"` |  |
 | config.eth.confirmationDepth | int | `1` |  |
 | config.eth.rpc | string | `"https://ethereum-holesky-rpc.publicnode.com"` |  |

--- a/charts/eigenda-proxy/templates/deployment.yaml
+++ b/charts/eigenda-proxy/templates/deployment.yaml
@@ -107,6 +107,7 @@ spec:
                 --eigenda.status-query-timeout=45m \
                 --eigenda.g1-path=$kzg_folder/g1.point \
                 --eigenda.g2-tau-path=$kzg_folder/g2.point.powerOf2 \
+                --eigenda.max-blob-length={{ .Values.config.maxBlobLength }} \
                 --eigenda.disable-tls=false \
                 {{- if .Values.config.routing.cacheTargets }}
                 --routing.cache-targets={{ .Values.config.routing.cacheTargets }} \

--- a/charts/eigenda-proxy/templates/deployment.yaml
+++ b/charts/eigenda-proxy/templates/deployment.yaml
@@ -38,6 +38,7 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.config.bigKZGFiles }}
       initContainers:
         - name: download-srs
           image: alpine:latest
@@ -82,6 +83,7 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /data
+      {{- end }}
       containers:
         - name: eigenda-proxy
           securityContext:
@@ -94,6 +96,7 @@ spec:
           args:
             - |
               mkdir -p /data/resources
+              kzg_folder={{ ternary "/data/resources" "/app/resources" .Values.config.bigKZGFiles }}
               exec /app/eigenda-proxy \
                 --addr=0.0.0.0 \
                 --port={{ .Values.services.api.port }} \
@@ -102,8 +105,8 @@ spec:
                 --eigenda.eth-rpc={{ .Values.config.eth.rpc }} \
                 --eigenda.svc-manager-addr={{ .Values.config.eth.serviceManagerAddr }} \
                 --eigenda.status-query-timeout=45m \
-                --eigenda.g1-path=/data/resources/g1.point \
-                --eigenda.g2-tau-path=/data/resources/g2.point.powerOf2 \
+                --eigenda.g1-path=$kzg_folder/g1.point \
+                --eigenda.g2-tau-path=$kzg_folder/g2.point.powerOf2 \
                 --eigenda.disable-tls=false \
                 {{- if .Values.config.routing.cacheTargets }}
                 --routing.cache-targets={{ .Values.config.routing.cacheTargets }} \
@@ -171,9 +174,11 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- if .Values.config.bigKZGFiles }}
           volumeMounts:
             - name: data
               mountPath: /data
+          {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -188,6 +193,7 @@ spec:
       {{- end }}
       updateStrategy:
         type: Recreate
+      {{- if .Values.config.bigKZGFiles }}
       volumes:
         - name: data
         {{- if .Values.persistence.enabled }}
@@ -196,3 +202,4 @@ spec:
         {{ else }}
           emptyDir: {}
         {{- end }}
+      {{- end }}

--- a/charts/eigenda-proxy/templates/pvc.yaml
+++ b/charts/eigenda-proxy/templates/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.persistence.enabled }}
+{{- if and .Values.persistence.enabled .Values.config.bigKZGFiles }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/charts/eigenda-proxy/values.yaml
+++ b/charts/eigenda-proxy/values.yaml
@@ -151,6 +151,7 @@ config:
     accessKeyId: ""
     accessKeySecret: ""
     path: ""
+  bigKZGFiles: false
 
 log:
   level: info

--- a/charts/eigenda-proxy/values.yaml
+++ b/charts/eigenda-proxy/values.yaml
@@ -152,6 +152,7 @@ config:
     accessKeySecret: ""
     path: ""
   bigKZGFiles: false
+  maxBlobLength: 32MiB
 
 log:
   level: info


### PR DESCRIPTION
Option to use smaller KZG files reducing operational costs (volume/download/etc...) for eigenda-proxy.