### PR TITLE
[op-dispute-mon] Avoid service name collision

### DIFF
--- a/charts/op-dispute-mon/Chart.yaml
+++ b/charts/op-dispute-mon/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: op-dispute-mon
 description: A Helm chart for Fault Proof Monitoring
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "main"
 maintainers:
   - name: cLabs

--- a/charts/op-dispute-mon/README.md
+++ b/charts/op-dispute-mon/README.md
@@ -1,6 +1,6 @@
 # op-dispute-mon
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: main](https://img.shields.io/badge/AppVersion-main-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: main](https://img.shields.io/badge/AppVersion-main-informational?style=flat-square)
 
 A Helm chart for Fault Proof Monitoring
 

--- a/charts/op-dispute-mon/templates/deployment.yaml
+++ b/charts/op-dispute-mon/templates/deployment.yaml
@@ -30,6 +30,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      enableServiceLinks: false
       serviceAccountName: {{ include "op-dispute-mon.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}


### PR DESCRIPTION
Fix error caused but K8s populated env vars from service names:

```
t=2024-11-18T11:55:28+0000 lvl=crit msg="Application failed" err="could not parse \"tcp://10.12.9.173:7300\" as int value from environment variable \"OP_DISPUTE_MON_METRICS_PORT\" for flag metrics.port: strconv.ParseInt: parsing \"tcp://10.12.9.173:7300\": invalid syntax"
```