### PR TITLE
Decouple prysm p2p tcp and udp ports

### DIFF
--- a/charts/prysm/Chart.yaml
+++ b/charts/prysm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: prysm
-version: 5.2.1
+version: 5.2.2
 appVersion: v5.2.0
 kubeVersion: "^1.18.0-0"
 description: Go implementation of Ethereum proof of stake.

--- a/charts/prysm/README.md
+++ b/charts/prysm/README.md
@@ -1,6 +1,6 @@
 # prysm
 
-![Version: 5.2.1](https://img.shields.io/badge/Version-5.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v5.2.0](https://img.shields.io/badge/AppVersion-v5.2.0-informational?style=flat-square)
+![Version: 5.2.2](https://img.shields.io/badge/Version-5.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v5.2.0](https://img.shields.io/badge/AppVersion-v5.2.0-informational?style=flat-square)
 
 Go implementation of Ethereum proof of stake.
 Initially based on [stakewise/helm-charts/prysm](https://github.com/stakewise/helm-charts/tree/main/charts/prysm).

--- a/charts/prysm/templates/_helpers.yaml
+++ b/charts/prysm/templates/_helpers.yaml
@@ -1,3 +1,6 @@
-{{- define "prysm.p2pPort" -}}
+{{- define "prysm.p2pTcpPort" -}}
 {{- printf "13000" -}}
+{{- end -}}
+{{- define "prysm.p2pUdpPort" -}}
+{{- printf "13001" -}}
 {{- end -}}

--- a/charts/prysm/templates/service-p2p.yaml
+++ b/charts/prysm/templates/service-p2p.yaml
@@ -23,13 +23,13 @@ spec:
   externalTrafficPolicy: Local
   ports:
     - name: p2p-tcp
-      port: {{ include "prysm.p2pPort" $ }}
+      port: {{ include "prysm.p2pTcpPort" $ }}
       protocol: TCP
       targetPort: p2p-tcp
       nodePort: {{ $port }}
   {{- if eq $.Values.p2pNodePort.type "NodePort" }}
     - name: p2p-udp
-      port: {{ include "prysm.p2pPort" $ }}
+      port: {{ include "prysm.p2pUdpPort" $ }}
       protocol: UDP
       targetPort: p2p-udp
       nodePort: {{ $port }}

--- a/charts/prysm/templates/statefulset.yaml
+++ b/charts/prysm/templates/statefulset.yaml
@@ -87,8 +87,8 @@ spec:
               echo "p2p-udp-port: $((EXTERNAL_PORT + 1))" >> /config/config.yaml;
           {{- else }}
               echo "p2p-host-ip: $POD_IP"   > /config/config.yaml;
-              echo 'p2p-tcp-port: {{ include "prysm.p2pPort" . }}' >> /config/config.yaml;
-              echo 'p2p-udp-port: {{ include "prysm.p2pPort" . }}' >> /config/config.yaml;
+              echo 'p2p-tcp-port: {{ include "prysm.p2pTcpPort" . }}' >> /config/config.yaml;
+              echo 'p2p-udp-port: {{ include "prysm.p2pUdpPort" . }}' >> /config/config.yaml;
           {{- end }}
               INDEX=$((${HOSTNAME##*-}+1));
               cat data/scripts/execution-endpoints.txt;
@@ -191,10 +191,10 @@ spec:
               protocol: TCP
           {{- if .Values.p2pNodePort.enabled }}
             - name: p2p-tcp
-              containerPort: {{ include "prysm.p2pPort" . }}
+              containerPort: {{ include "prysm.p2pTcpPort" . }}
               protocol: TCP
             - name: p2p-udp
-              containerPort: {{ include "prysm.p2pPort" . }}
+              containerPort: {{ include "prysm.p2pUdpPort" . }}
               protocol: UDP
           {{- end }}
           {{- if .Values.http.enabled }}


### PR DESCRIPTION
Prysm now complains if use the same port for tcp and udp p2p.