### PR TITLE
Allow the option for skipping UDP port op-geth

### DIFF
--- a/charts/op-geth/Chart.yaml
+++ b/charts/op-geth/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 name: op-geth
 apiVersion: v2
-version: 0.3.6
+version: 0.3.7
 description: Celo implementation for op-geth execution engine (Optimism Rollup)
 home: https://clabs.co
 sources:

--- a/charts/op-geth/templates/service-p2p.yaml
+++ b/charts/op-geth/templates/service-p2p.yaml
@@ -49,6 +49,7 @@ spec:
     {{- include "op-geth.selectorLabels" $ | nindent 4 }}
     statefulset.kubernetes.io/pod-name: {{ template "op-geth.fullname" $ }}-{{ $index }}
 ---
+{{- if not .skipUDPService }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -85,6 +86,7 @@ spec:
   selector:
     {{- include "op-geth.selectorLabels" $ | nindent 4 }}
     statefulset.kubernetes.io/pod-name: {{ template "op-geth.fullname" $ }}-{{ $index }}
+{{- end }}
 {{- else }}
 ---
 apiVersion: v1

--- a/charts/op-geth/values.yaml
+++ b/charts/op-geth/values.yaml
@@ -145,6 +145,7 @@ services:
     port: 30303
     annotations: {}
     publishNotReadyAddresses: true
+    skipUDPService: false
 ingress:
   http:
     enabled: false


### PR DESCRIPTION
Mixed protocols are not supported when using a GCP Internal LB, so we need to disable one of them.

Disabling UDP should not have impact in cases when GCP InternalLB are used, especially if all internal nodes are configured as static, as in this case typically will be preferred to disable discovery.