### PR TITLE
succinct-game-monitor: add configurable replicas value

### DIFF
--- a/charts/succinct-game-monitor/Chart.yaml
+++ b/charts/succinct-game-monitor/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: succinct-game-monitor
 description: A Helm chart for the succinct game monitor
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: latest
 maintainers:
   - name: cLabs

--- a/charts/succinct-game-monitor/README.md
+++ b/charts/succinct-game-monitor/README.md
@@ -1,6 +1,6 @@
 # succinct-game-monitor
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 A Helm chart for the succinct game monitor
 
@@ -42,6 +42,7 @@ A Helm chart for the succinct game monitor
 | podLabels | object | `{}` | Custom pod labels |
 | podSecurityContext | object | `{}` | Custom pod security context |
 | readinessProbe | object | `{}` | Readiness probe configuration |
+| replicas | int | `1` | Number of replicas |
 | resources | object | `{}` | Container resources |
 | securityContext | object | `{}` | Custom container security context |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |

--- a/charts/succinct-game-monitor/templates/statefulset.yaml
+++ b/charts/succinct-game-monitor/templates/statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "app.labels" . | nindent 4 }}
 spec:
   serviceName: {{ include "app.fullname" . }}
-  replicas: 1
+  replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
       {{- include "app.selectorLabels" . | nindent 6 }}

--- a/charts/succinct-game-monitor/values.yaml
+++ b/charts/succinct-game-monitor/values.yaml
@@ -2,6 +2,9 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# -- Number of replicas
+replicas: 1
+
 # -- Chart name override
 nameOverride: ""
 # -- Chart full name override


### PR DESCRIPTION
## Summary
- Add a `replicas` value (default: `1`) to `values.yaml` so the StatefulSet replica count can be configured at deploy time
- Replace the hardcoded `replicas: 1` in `statefulset.yaml` with `{{ .Values.replicas }}`
- Bump chart version `0.1.1` → `0.1.2`