### PR TITLE
op-succinct: add config.tx.confirmation_timeout and config.sync.l1_confirmations

### DIFF
--- a/charts/op-succinct/Chart.yaml
+++ b/charts/op-succinct/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: op-succinct
 description: A Helm chart for op-succinct proposer and challenger
 type: application
-version: 1.2.0-rc.2
+version: 1.2.0-rc.3
 appVersion: 2.0.0
 maintainers:
   - name: cLabs

--- a/charts/op-succinct/README.md
+++ b/charts/op-succinct/README.md
@@ -1,6 +1,6 @@
 # op-succinct
 
-![Version: 1.2.0-rc.2](https://img.shields.io/badge/Version-1.2.0--rc.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 1.2.0-rc.3](https://img.shields.io/badge/Version-1.2.0--rc.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 A Helm chart for op-succinct proposer and challenger
 
@@ -52,6 +52,8 @@ A Helm chart for op-succinct proposer and challenger
 | config.secret_env | object | `{"existing_name":"","overwrites":{}}` | the `PRIVATE_KEY` is only required when `config.remote_signing.enabled` is `false`. |
 | config.secret_env.existing_name | string | `""` | Use an existing kubernetes secret by it's secret name |
 | config.secret_env.overwrites | object | `{}` | into the executor. |
+| config.sync.l1_confirmations | string | `""` | Number of L1 blocks behind `latest` to pin reads during sync cycles, as a safety margin for lagging load-balanced RPC backends (proposer only; defaults to 0 = use latest). |
+| config.tx.confirmation_timeout | string | `""` | Timeout (in seconds) for waiting on L1 transaction confirmations |
 | enableServiceLinks | bool | `false` | Kubernetes enableServiceLinks |
 | extraArgs | list | `[]` |  |
 | fullnameOverride | string | `""` | Chart full name override |

--- a/charts/op-succinct/templates/configmap.yaml
+++ b/charts/op-succinct/templates/configmap.yaml
@@ -44,7 +44,17 @@ data:
   {{- end }}
   FETCH_INTERVAL: "{{ .fetch }}"
   {{- end}}
+  {{- with .tx}}
+  {{- if .confirmation_timeout }}
+  TX_CONFIRMATION_TIMEOUT: "{{ .confirmation_timeout }}"
+  {{- end }}
+  {{- end}}
   {{- if eq $.Values.mode "proposer" }}
+  {{- with .sync}}
+  {{- if .l1_confirmations }}
+  SYNC_L1_CONFIRMATIONS: "{{ .l1_confirmations }}"
+  {{- end }}
+  {{- end}}
   {{- with .proof}}
   {{- if .agg_proof_mode }}
   AGG_PROOF_MODE: {{ .agg_proof_mode | quote }}

--- a/charts/op-succinct/values.yaml
+++ b/charts/op-succinct/values.yaml
@@ -72,6 +72,12 @@ config:
     proposal: 20
     # -- Fetch interval
     fetch: 30
+  tx:
+    # -- Timeout (in seconds) for waiting on L1 transaction confirmations
+    confirmation_timeout: ""
+  sync:
+    # -- Number of L1 blocks behind `latest` to pin reads during sync cycles, as a safety margin for lagging load-balanced RPC backends (proposer only; defaults to 0 = use latest).
+    l1_confirmations: ""
   remote_signing:
     # -- use a remote signer for signing the l1 transactions instead
     # -- of reading the "PRIVATE_KEY" env-var and signing locally.


### PR DESCRIPTION
## Summary
- Expose `TX_CONFIRMATION_TIMEOUT` (proposer + challenger) and `SYNC_L1_CONFIRMATIONS` (proposer only) as first-class chart values under `config.tx` / `config.sync`.
- Bumps chart version to `1.2.0-rc.3`.

## Test plan
- [x] `helm lint charts/op-succinct/`
- [x] `helm template ... --set mode=proposer --set config.tx.confirmation_timeout=180 --set config.sync.l1_confirmations=5` → both env vars render
- [x] `helm template ... --set mode=challenger --set config.tx.confirmation_timeout=180 --set config.sync.l1_confirmations=5` → only `TX_CONFIRMATION_TIMEOUT` renders (sync correctly gated to proposer)
- [x] `helm template ... --set mode=proposer` (defaults) → neither env var present
- [ ] CI: chart-testing install in kind cluster
- [ ] CI: helm-docs regenerates README

🤖 Generated with [Claude Code](https://claude.com/claude-code)