### PR TITLE
op-geth: add PDB and topology spread options

### DIFF
--- a/charts/op-geth/Chart.yaml
+++ b/charts/op-geth/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 name: op-geth
 apiVersion: v2
-version: 0.3.12
+version: 0.3.13
 description: Celo implementation for op-geth execution engine (Optimism Rollup)
 home: https://clabs.co
 sources:

--- a/charts/op-geth/README.md
+++ b/charts/op-geth/README.md
@@ -1,6 +1,6 @@
 # op-geth
 
-![Version: 0.3.12](https://img.shields.io/badge/Version-0.3.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.0](https://img.shields.io/badge/AppVersion-v1.0.0-informational?style=flat-square)
+![Version: 0.3.13](https://img.shields.io/badge/Version-0.3.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.0](https://img.shields.io/badge/AppVersion-v1.0.0-informational?style=flat-square)
 
 Celo implementation for op-geth execution engine (Optimism Rollup)
 Initially based on [dysnix/charts/op-geth](https://github.com/dysnix/charts/tree/main/dysnix/op-geth).
@@ -120,6 +120,9 @@ Initially based on [dysnix/charts/op-geth](https://github.com/dysnix/charts/tree
 | persistence.pvc.storageClass | string | `""` |  |
 | persistence.type | string | `"pvc"` |  |
 | podAnnotations | object | `{}` |  |
+| podDisruptionBudget.enabled | bool | `false` |  |
+| podDisruptionBudget.maxUnavailable | string | `""` |  |
+| podDisruptionBudget.minAvailable | string | `""` |  |
 | podLabels | object | `{}` |  |
 | podSecurityContext.fsGroup | int | `10001` |  |
 | podStatusLabels | object | `{}` |  |
@@ -203,6 +206,7 @@ Initially based on [dysnix/charts/op-geth](https://github.com/dysnix/charts/tree
 | syncToS3.enabled | bool | `false` |  |
 | terminationGracePeriodSeconds | int | `300` |  |
 | tolerations | list | `[]` |  |
+| topologySpreadConstraints | list | `[]` |  |
 | updateStrategy.type | string | `"RollingUpdate"` |  |
 
 ----------------------------------------------

--- a/charts/op-geth/templates/pdb.yaml
+++ b/charts/op-geth/templates/pdb.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+{{- if and (empty .Values.podDisruptionBudget.minAvailable) (empty .Values.podDisruptionBudget.maxUnavailable) }}
+{{- fail "podDisruptionBudget requires either minAvailable or maxUnavailable" }}
+{{- end }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "op-geth.fullname" . }}
+  labels:
+    {{- include "op-geth.labels" . | nindent 4 }}
+spec:
+  {{- with .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ . }}
+  {{- end }}
+  {{- with .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "op-geth.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/op-geth/templates/statefulset.yaml
+++ b/charts/op-geth/templates/statefulset.yaml
@@ -56,6 +56,10 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/charts/op-geth/values.yaml
+++ b/charts/op-geth/values.yaml
@@ -217,9 +217,16 @@ persistence:
 
 affinity: {}
 
+topologySpreadConstraints: []
+
 nodeSelector: {}
 
 tolerations: []
+
+podDisruptionBudget:
+  enabled: false
+  minAvailable: ""
+  maxUnavailable: ""
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/op-node/README.md
+++ b/charts/op-node/README.md
@@ -1,6 +1,6 @@
 # op-node
 
-![Version: 0.4.20](https://img.shields.io/badge/Version-0.4.20-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.0](https://img.shields.io/badge/AppVersion-v1.0.0-informational?style=flat-square)
+![Version: 0.4.21](https://img.shields.io/badge/Version-0.4.21-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.0](https://img.shields.io/badge/AppVersion-v1.0.0-informational?style=flat-square)
 
 Celo implementation for op-node consensus engine (Optimism Rollup)
 Initially based on [dysnix/charts/op-node](https://github.com/dysnix/charts/tree/main/dysnix/op-node).
@@ -42,6 +42,7 @@ Initially based on [dysnix/charts/op-node](https://github.com/dysnix/charts/tree
 | config.l1.rpckind | string | `"any"` |  |
 | config.l1.runtimeConfigReloadInterval | string | `"10m0s"` |  |
 | config.l1.trustrpc | bool | `false` |  |
+| config.l2.engineKind | string | `""` |  |
 | config.l2.engineRPCTimeout | string | `""` |  |
 | config.l2.namePattern | string | `""` |  |
 | config.l2.port | string | `""` |  |
@@ -120,6 +121,9 @@ Initially based on [dysnix/charts/op-node](https://github.com/dysnix/charts/tree
 | persistence.pvc.size | string | `"1Gi"` |  |
 | persistence.pvc.storageClass | string | `""` |  |
 | persistence.type | string | `"pvc"` |  |
+| podDisruptionBudget.enabled | bool | `false` |  |
+| podDisruptionBudget.maxUnavailable | string | `""` |  |
+| podDisruptionBudget.minAvailable | string | `""` |  |
 | podSecurityContext | object | `{}` |  |
 | readinessProbe.enabled | bool | `false` |  |
 | replicaCount | int | `1` |  |
@@ -172,6 +176,7 @@ Initially based on [dysnix/charts/op-node](https://github.com/dysnix/charts/tree
 | statefulset.podAnnotations | object | `{}` |  |
 | terminationGracePeriodSeconds | int | `300` |  |
 | tolerations | list | `[]` |  |
+| topologySpreadConstraints | list | `[]` |  |
 | updateStrategy.type | string | `"RollingUpdate"` |  |
 
 ----------------------------------------------


### PR DESCRIPTION
## Summary
- add optional PodDisruptionBudget support to op-geth
- add topologySpreadConstraints passthrough to op-geth StatefulSet
- bump op-geth chart version to 0.3.13

## Testing
- helm template op-geth with PDB and topologySpreadConstraints enabled
- helm template op-geth with PDB enabled and no availability value to verify validation failure