### PR TITLE
op-conductor: add PDB and topology spread options

### DIFF
--- a/charts/op-conductor/Chart.yaml
+++ b/charts/op-conductor/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 name: op-conductor
 apiVersion: v2
-version: 0.1.3
+version: 0.1.4
 description: Helm chart deploying OP Conductor, a HA controller for op-node
 home: https://clabs.co
 sources:

--- a/charts/op-conductor/README.md
+++ b/charts/op-conductor/README.md
@@ -1,6 +1,6 @@
 # op-conductor
 
-![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.8.0](https://img.shields.io/badge/AppVersion-v1.8.0-informational?style=flat-square)
+![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.8.0](https://img.shields.io/badge/AppVersion-v1.8.0-informational?style=flat-square)
 
 Helm chart deploying OP Conductor, a HA controller for op-node
 
@@ -66,6 +66,9 @@ Helm chart deploying OP Conductor, a HA controller for op-node
 | persistence.pvc.size | string | `"1Gi"` |  |
 | persistence.pvc.storageClass | string | `""` |  |
 | persistence.type | string | `"pvc"` |  |
+| podDisruptionBudget.enabled | bool | `false` |  |
+| podDisruptionBudget.maxUnavailable | string | `""` |  |
+| podDisruptionBudget.minAvailable | string | `""` |  |
 | podManagementPolicy | string | `"Parallel"` |  |
 | podSecurityContext | object | `{}` |  |
 | replicaCount | int | `1` |  |
@@ -85,6 +88,7 @@ Helm chart deploying OP Conductor, a HA controller for op-node
 | statefulset.labels | object | `{}` |  |
 | statefulset.podAnnotations | object | `{}` |  |
 | tolerations | list | `[]` |  |
+| topologySpreadConstraints | list | `[]` |  |
 | updateStrategy.type | string | `"RollingUpdate"` |  |
 
 ----------------------------------------------

--- a/charts/op-conductor/templates/pdb.yaml
+++ b/charts/op-conductor/templates/pdb.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+{{- if and (empty .Values.podDisruptionBudget.minAvailable) (empty .Values.podDisruptionBudget.maxUnavailable) }}
+{{- fail "podDisruptionBudget requires either minAvailable or maxUnavailable" }}
+{{- end }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "op-conductor.fullname" . }}
+  labels:
+    {{- include "op-conductor.labels" . | nindent 4 }}
+spec:
+  {{- with .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ . }}
+  {{- end }}
+  {{- with .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "op-conductor.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/op-conductor/templates/statefulset.yaml
+++ b/charts/op-conductor/templates/statefulset.yaml
@@ -37,6 +37,10 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/charts/op-conductor/values.yaml
+++ b/charts/op-conductor/values.yaml
@@ -3,7 +3,13 @@ replicaCount: 1
 podManagementPolicy: Parallel
 nodeSelector: {}
 affinity: {}
+topologySpreadConstraints: []
 tolerations: []
+
+podDisruptionBudget:
+  enabled: false
+  minAvailable: ""
+  maxUnavailable: ""
 
 init:
   image:


### PR DESCRIPTION
## Summary
- add optional PodDisruptionBudget support to op-conductor
- add topologySpreadConstraints passthrough to the op-conductor StatefulSet
- bump op-conductor chart version to 0.1.4

## Testing
- helm template op-conductor with PDB and topologySpreadConstraints enabled
- helm template op-conductor with PDB enabled and no availability value to verify validation failure