### PR TITLE
feat(op-reth): add snapshot-download initContainer (celo-reth download)

### DIFF
--- a/charts/op-reth/Chart.yaml
+++ b/charts/op-reth/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 name: op-reth
 apiVersion: v2
-version: 0.0.3
+version: 0.0.4
 description: Celo implementation for op-reth execution engine (Optimism Rollup)
 home: https://clabs.co
 sources:

--- a/charts/op-reth/README.md
+++ b/charts/op-reth/README.md
@@ -1,6 +1,6 @@
 # op-reth
 
-![Version: 0.0.3](https://img.shields.io/badge/Version-0.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.0](https://img.shields.io/badge/AppVersion-v1.0.0-informational?style=flat-square)
+![Version: 0.0.4](https://img.shields.io/badge/Version-0.0.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.0](https://img.shields.io/badge/AppVersion-v1.0.0-informational?style=flat-square)
 
 Celo implementation for op-reth execution engine (Optimism Rollup)
 Initially based on [dysnix/charts/op-geth](https://github.com/dysnix/charts/tree/main/dysnix/op-geth).
@@ -199,6 +199,13 @@ Initially based on [dysnix/charts/op-geth](https://github.com/dysnix/charts/tree
 | services.rpc.type | string | `"ClusterIP"` |  |
 | services.rpc.wsPort | int | `8545` |  |
 | sidecarContainers | list | `[]` | Sidecar containers, can be templated |
+| snapshot | object | `{"components":"full","enabled":false,"extraArgs":[],"force":false,"manifestUrl":"","url":""}` | Bootstrap an empty datadir from a published snapshot using `celo-reth download` (manifest-based, served by default from snapshots.celo.org). This is an alternative to `init.genesis` / `initFromS3`; the init container runs before `init-genesis` and shares the `$datadir/.initialized` marker, so it is a no-op once the node is initialized and safe to leave enabled across restarts. |
+| snapshot.components | string | `"full"` | Component set to download. One of: "minimal", "full", "archive". Always passed so the interactive selection TUI is never triggered inside the init container. Use "archive" for archive nodes (`config.full: false`). |
+| snapshot.enabled | bool | `false` | Enable the snapshot-download initContainer. |
+| snapshot.extraArgs | list | `[]` | Extra arguments appended to `celo-reth download` (can be templated). |
+| snapshot.force | bool | `false` | Re-download even if the datadir is already initialized (bypasses the `$datadir/.initialized` guard). |
+| snapshot.manifestUrl | string | `""` | Override the snapshot manifest URL. Empty uses celo-reth's per-chain default (`https://snapshots.celo.org/mainnet/manifest.json` for chain `celo`, `https://snapshots.celo.org/celo-sepolia/manifest.json` for `celo-sepolia`). Mutually exclusive with `url`. |
+| snapshot.url | string | `""` | Download a single archive (`.tar.zst` / `.tar.lz4`) from this URL instead of a manifest. Mutually exclusive with `manifestUrl`. |
 | startupProbe.enabled | bool | `false` |  |
 | startupProbe.exec.command[0] | string | `"sh"` |  |
 | startupProbe.exec.command[1] | string | `"/scripts/wait-for-sync.sh"` |  |

--- a/charts/op-reth/templates/configmap-scripts.yaml
+++ b/charts/op-reth/templates/configmap-scripts.yaml
@@ -15,6 +15,10 @@ data:
     {{- include (print $.Template.BasePath "/scripts/_init-genesis.tpl") . | nindent 4 }}
   split-parameters.sh: |-
     {{- include (print $.Template.BasePath "/scripts/_split-parameters.tpl") . | nindent 4 }}
+  {{- if .Values.snapshot.enabled }}
+  init-from-snapshot.sh: |-
+    {{- include (print $.Template.BasePath "/scripts/_init-from-snapshot.tpl") . | nindent 4 }}
+  {{- end }}
   {{- if or .Values.syncToS3.enabled .Values.initFromS3.enabled }}
   init-from-s3.sh: |-
     {{- include (print $.Template.BasePath "/scripts/_init-from-s3.tpl") . | nindent 4 }}

--- a/charts/op-reth/templates/scripts/_init-from-snapshot.tpl
+++ b/charts/op-reth/templates/scripts/_init-from-snapshot.tpl
@@ -1,0 +1,40 @@
+#!/usr/bin/env sh
+set -e
+{{- if not (has .Values.snapshot.components (list "minimal" "full" "archive")) }}
+{{- fail (printf "snapshot.components must be one of \"minimal\", \"full\" or \"archive\"; got %q" .Values.snapshot.components) }}
+{{- end }}
+{{- if and .Values.snapshot.manifestUrl .Values.snapshot.url }}
+{{- fail "snapshot.manifestUrl and snapshot.url are mutually exclusive" }}
+{{- end }}
+
+datadir="{{ .Values.persistence.mountPath | default .Values.config.datadir }}"
+
+{{- if not .Values.snapshot.force }}
+if [ -f "$datadir/.initialized" ]; then
+    echo "Datadir already initialized; skipping snapshot download."
+    exit 0
+fi
+{{- end }}
+
+echo "Bootstrapping datadir from snapshot via 'celo-reth download --{{ .Values.snapshot.components }}'..."
+celo-reth download \
+  --datadir={{ .Values.config.datadir }} \
+{{- if .Values.config.chain }}
+  --chain={{ .Values.config.chain }} \
+{{- end }}
+{{- with .Values.snapshot.manifestUrl }}
+  --manifest-url={{ . }} \
+{{- end }}
+{{- with .Values.snapshot.url }}
+  --url={{ . }} \
+{{- end }}
+  --force \
+{{- with .Values.snapshot.extraArgs }}
+{{- range . }}
+  {{ tpl . $ }} \
+{{- end }}
+{{- end }}
+  --{{ .Values.snapshot.components }}
+
+touch "$datadir/.initialized"
+echo "Snapshot download complete; datadir marked initialized."

--- a/charts/op-reth/templates/statefulset.yaml
+++ b/charts/op-reth/templates/statefulset.yaml
@@ -77,6 +77,21 @@ spec:
         - name: data
           mountPath: /data
       {{- end }}
+      {{- if .Values.snapshot.enabled }}
+      - name: init-from-snapshot
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+        {{- with .Values.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        command: ["sh", "/scripts/init-from-snapshot.sh"]
+        volumeMounts:
+        - name: scripts
+          mountPath: /scripts
+        - name: data
+          mountPath: {{ .Values.persistence.mountPath | default .Values.config.datadir }}
+      {{- end }}
       {{- if or .Values.init.genesis.enabled .Values.init.rollup.enabled }}
       - name: init-genesis
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/op-reth/values.yaml
+++ b/charts/op-reth/values.yaml
@@ -432,6 +432,25 @@ init:
   # -- Extra arguments for the celo-reth init-genesis container (can be templated).
   extraArgs: []
 
+# -- Bootstrap an empty datadir from a published snapshot using `celo-reth download`
+# (manifest-based, served by default from snapshots.celo.org). This is an alternative to
+# `init.genesis` / `initFromS3`; the init container runs before `init-genesis` and shares
+# the `$datadir/.initialized` marker, so it is a no-op once the node is initialized and
+# safe to leave enabled across restarts.
+snapshot:
+  # -- Enable the snapshot-download initContainer.
+  enabled: false
+  # -- Re-download even if the datadir is already initialized (bypasses the `$datadir/.initialized` guard).
+  force: false
+  # -- Component set to download. One of: "minimal", "full", "archive". Always passed so the interactive selection TUI is never triggered inside the init container. Use "archive" for archive nodes (`config.full: false`).
+  components: full
+  # -- Override the snapshot manifest URL. Empty uses celo-reth's per-chain default (`https://snapshots.celo.org/mainnet/manifest.json` for chain `celo`, `https://snapshots.celo.org/celo-sepolia/manifest.json` for `celo-sepolia`). Mutually exclusive with `url`.
+  manifestUrl: ""
+  # -- Download a single archive (`.tar.zst` / `.tar.lz4`) from this URL instead of a manifest. Mutually exclusive with `manifestUrl`.
+  url: ""
+  # -- Extra arguments appended to `celo-reth download` (can be templated).
+  extraArgs: []
+
 s3config:
   image:
     repository: peakcom/s5cmd


### PR DESCRIPTION
## What

Adds an opt-in **snapshot download** option to the `op-reth` chart: an `init-from-snapshot` initContainer that bootstraps an empty datadir from a published snapshot manifest using `celo-reth download`. This is an alternative to the existing `init.genesis` (sync from scratch) and `initFromS3` (s5cmd raw sync) bootstrap paths.

## How it works

- The new `init-from-snapshot` initContainer runs **before** `init-genesis` and shares the chart's `$datadir/.initialized` marker:
  - if `$datadir/.initialized` already exists → it is a no-op (skips), so it is safe to leave enabled across restarts;
  - otherwise it runs `celo-reth download` and `touch`es the marker on success.
- It always passes a component-set flag (`--minimal` / `--full` / `--archive`) so the interactive TUI selector never blocks the init container, plus `--force` for robustness against interrupted/partial downloads.
- `snapshot.manifestUrl` and `snapshot.url` are mutually exclusive (validated at template time). An empty `manifestUrl` uses celo-reth's per-chain default (`https://snapshots.celo.org/mainnet/manifest.json` for chain `celo`, `https://snapshots.celo.org/celo-sepolia/manifest.json` for `celo-sepolia`).

## Values

| Key | Default | Description |
|---|---|---|
| `snapshot.enabled` | `false` | Enable the snapshot-download initContainer. |
| `snapshot.force` | `false` | Re-download even if the datadir is already initialized. |
| `snapshot.components` | `full` | Component set: `minimal` / `full` / `archive` (use `archive` for archive nodes). |
| `snapshot.manifestUrl` | `""` | Override the manifest URL (per-chain default if empty). |
| `snapshot.url` | `""` | Single-archive URL instead of a manifest. |
| `snapshot.extraArgs` | `[]` | Extra args appended to `celo-reth download`. |

Example:

```yaml
config:
  chain: celo-sepolia
snapshot:
  enabled: true
  components: archive
```

## Verification

- `helm lint` passes with snapshot enabled and disabled.
- `helm template` renders 0 `init-from-snapshot` refs when disabled; when enabled it emits a valid `celo-reth download --datadir=/celo --chain=celo --force --full`, guarded by the `.initialized` marker and ordered before `init-genesis`.
- Template validation rejects an invalid `snapshot.components` and rejects `manifestUrl` + `url` set together.
- Chart bumped to `0.0.4`; `README.md` regenerated via `helm-docs`.
