### PR TITLE
feat(op-reth): add proofs-history initContainer and node flags

### DIFF
--- a/charts/op-reth/Chart.yaml
+++ b/charts/op-reth/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 name: op-reth
 apiVersion: v2
-version: 0.0.4
+version: 0.0.5
 description: Celo implementation for op-reth execution engine (Optimism Rollup)
 home: https://clabs.co
 sources:

--- a/charts/op-reth/README.md
+++ b/charts/op-reth/README.md
@@ -1,6 +1,6 @@
 # op-reth
 
-![Version: 0.0.4](https://img.shields.io/badge/Version-0.0.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.0](https://img.shields.io/badge/AppVersion-v1.0.0-informational?style=flat-square)
+![Version: 0.0.5](https://img.shields.io/badge/Version-0.0.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.0](https://img.shields.io/badge/AppVersion-v1.0.0-informational?style=flat-square)
 
 Celo implementation for op-reth execution engine (Optimism Rollup)
 Initially based on [dysnix/charts/op-geth](https://github.com/dysnix/charts/tree/main/dysnix/op-geth).
@@ -138,6 +138,13 @@ Initially based on [dysnix/charts/op-geth](https://github.com/dysnix/charts/tree
 | podLabels | object | `{}` | Extra pod labels |
 | podSecurityContext.fsGroup | int | `10001` |  |
 | podStatusLabels | object | `{}` | Labels marking the node as ready to serve traffic. Used as selector for the RPC service together with `.Values.podLabels` and default labels. |
+| proofsHistory | object | `{"enabled":false,"minSyncedBlock":1,"storagePath":"","storageVersion":"v2","verificationInterval":0,"window":1209600}` | Historical-proofs ExEx ("Bounded History Sidecar"): persists state/withdrawal proofs to a dedicated MDBX store and serves them via an `eth_getProof` override. A one-time, idempotent `celo-reth proofs init` initContainer anchors the store at the current chain tip (celo-reth refuses to launch with `--proofs-history` against an uninitialized store). Init is skipped while the node head is below `minSyncedBlock` (e.g. an empty datadir still doing initial sync), and the node only receives the `--proofs-history` flags once the store is initialized — so the feature is safe to leave enabled across restarts and for snapshot- or genesis-bootstrapped nodes. |
+| proofsHistory.enabled | bool | `false` | Enable the proofs-history init container and node flags. |
+| proofsHistory.minSyncedBlock | int | `1` | Minimum head block (from the headers static files) required before `proofs init` runs and the node launches with `--proofs-history`. Guards against initializing while the node is still doing its initial sync. |
+| proofsHistory.storagePath | string | `""` | Filesystem path for the MDBX proofs store. Empty defaults to `<datadir>/proofs-history`. |
+| proofsHistory.storageVersion | string | `"v2"` | On-disk store schema version. One of: "v1", "v2". v2 = history-aware reads at any block within the window. |
+| proofsHistory.verificationInterval | int | `0` | Re-verification interval in blocks. 0 omits the flag (uses celo-reth's default). |
+| proofsHistory.window | int | `1209600` | Retention window in BLOCKS. Proofs accumulate forward from the init point (no backfill); older proofs are pruned. 1209600 = reth's MAX_ETH_PROOF_WINDOW cap (~14 days at 1s blocks). |
 | readinessProbe.enabled | bool | `false` |  |
 | readinessProbe.exec.command[0] | string | `"sh"` |  |
 | readinessProbe.exec.command[1] | string | `"/scripts/readiness.sh"` |  |

--- a/charts/op-reth/templates/configmap-scripts.yaml
+++ b/charts/op-reth/templates/configmap-scripts.yaml
@@ -19,6 +19,10 @@ data:
   init-from-snapshot.sh: |-
     {{- include (print $.Template.BasePath "/scripts/_init-from-snapshot.tpl") . | nindent 4 }}
   {{- end }}
+  {{- if .Values.proofsHistory.enabled }}
+  init-proofs-history.sh: |-
+    {{- include (print $.Template.BasePath "/scripts/_init-proofs-history.tpl") . | nindent 4 }}
+  {{- end }}
   {{- if or .Values.syncToS3.enabled .Values.initFromS3.enabled }}
   init-from-s3.sh: |-
     {{- include (print $.Template.BasePath "/scripts/_init-from-s3.tpl") . | nindent 4 }}

--- a/charts/op-reth/templates/scripts/_init-proofs-history.tpl
+++ b/charts/op-reth/templates/scripts/_init-proofs-history.tpl
@@ -1,0 +1,46 @@
+#!/usr/bin/env sh
+set -e
+
+datadir="{{ .Values.persistence.mountPath | default .Values.config.datadir }}"
+storagePath="{{ .Values.proofsHistory.storagePath | default (printf "%s/proofs-history" .Values.config.datadir) }}"
+minSyncedBlock={{ .Values.proofsHistory.minSyncedBlock | int64 }}
+
+# Highest block present in the headers static files (reth names them
+# "static_file_headers_<start>_<end>"). Cheap "is the node synced?" probe that avoids
+# starting the node: "proofs init" anchors the store at the chain tip, so initializing while
+# the node is still doing its initial sync would anchor the store far behind the network.
+headBlock=0
+if [ -d "$datadir/static_files" ]; then
+  for f in "$datadir"/static_files/static_file_headers_*; do
+    [ -e "$f" ] || continue
+    end=$(basename "$f" | cut -d_ -f5 | sed 's/[^0-9].*$//')
+    case "$end" in
+      ''|*[!0-9]*) continue ;;
+    esac
+    if [ "$end" -gt "$headBlock" ]; then headBlock="$end"; fi
+  done
+fi
+
+if [ "$headBlock" -lt "$minSyncedBlock" ]; then
+  echo "proofs-history: head block $headBlock < minSyncedBlock $minSyncedBlock; skipping init (node not synced)."
+  # Drop the marker so the node container launches WITHOUT --proofs-history until a later
+  # restart finds the node synced past minSyncedBlock and initializes the store.
+  rm -f "$datadir/.proofs-initialized"
+  exit 0
+fi
+
+echo "proofs-history: initializing store at $storagePath (head block $headBlock)..."
+# Idempotent: "proofs init" anchors the store at the current chain tip and is a no-op once
+# initialized, so this is safe to re-run on every pod restart.
+celo-reth proofs init \
+  --datadir={{ .Values.config.datadir }} \
+{{- if .Values.config.chain }}
+  --chain={{ .Values.config.chain }} \
+{{- else }}
+  --chain=$datadir/genesis.json \
+{{- end }}
+  --proofs-history.storage-path="$storagePath" \
+  --proofs-history.storage-version={{ .Values.proofsHistory.storageVersion }}
+
+touch "$datadir/.proofs-initialized"
+echo "proofs-history: store initialized."

--- a/charts/op-reth/templates/statefulset.yaml
+++ b/charts/op-reth/templates/statefulset.yaml
@@ -200,6 +200,21 @@ spec:
           mountPath: /scripts
         - name: data
           mountPath: {{ .Values.persistence.mountPath | default .Values.config.datadir }}
+      {{- if .Values.proofsHistory.enabled }}
+      - name: init-proofs-history
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+        {{- with .Values.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        command: ["sh", "/scripts/init-proofs-history.sh"]
+        volumeMounts:
+        - name: scripts
+          mountPath: /scripts
+        - name: data
+          mountPath: {{ .Values.persistence.mountPath | default .Values.config.datadir }}
+      {{- end }}
       {{- with .Values.extraInitContainers }}
         {{- tpl (toYaml . | nindent 6) $ }}
       {{- end }}
@@ -224,6 +239,12 @@ spec:
           natFlag="--nat=extip:$(cat $datadir/announce_ip)"
           {{- end }}
           [ -f $datadir/nodeKey ] && nodeKeyFlag="--p2p-secret-key=$datadir/nodeKey" || nodeKeyFlag=""
+          {{- if .Values.proofsHistory.enabled }}
+          proofsHistoryFlags=""
+          if [ -f $datadir/.proofs-initialized ]; then
+            proofsHistoryFlags="--proofs-history --proofs-history.storage-path={{ .Values.proofsHistory.storagePath | default (printf "%s/proofs-history" .Values.config.datadir) }} --proofs-history.storage-version={{ .Values.proofsHistory.storageVersion }} --proofs-history.window={{ .Values.proofsHistory.window | int64 }}{{ if gt (int64 .Values.proofsHistory.verificationInterval) 0 }} --proofs-history.verification-interval={{ .Values.proofsHistory.verificationInterval | int64 }}{{ end }}"
+          fi
+          {{- end }}
           exec celo-reth node \
             --datadir={{ .Values.config.datadir }} \
             {{- if .Values.config.chain }}
@@ -371,6 +392,9 @@ spec:
             --discovery.v5.port={{ .Values.config.port }} \
             {{- end }}
             $natFlag \
+            {{- if .Values.proofsHistory.enabled }}
+            $proofsHistoryFlags \
+            {{- end }}
             {{- with .Values.extraArgs }}
             {{- range . }}
             {{- tpl (.) $ | nindent 12 }} \

--- a/charts/op-reth/values.yaml
+++ b/charts/op-reth/values.yaml
@@ -451,6 +451,27 @@ snapshot:
   # -- Extra arguments appended to `celo-reth download` (can be templated).
   extraArgs: []
 
+# -- Historical-proofs ExEx ("Bounded History Sidecar"): persists state/withdrawal proofs to a
+# dedicated MDBX store and serves them via an `eth_getProof` override. A one-time, idempotent
+# `celo-reth proofs init` initContainer anchors the store at the current chain tip (celo-reth
+# refuses to launch with `--proofs-history` against an uninitialized store). Init is skipped while
+# the node head is below `minSyncedBlock` (e.g. an empty datadir still doing initial sync), and the
+# node only receives the `--proofs-history` flags once the store is initialized — so the feature is
+# safe to leave enabled across restarts and for snapshot- or genesis-bootstrapped nodes.
+proofsHistory:
+  # -- Enable the proofs-history init container and node flags.
+  enabled: false
+  # -- Filesystem path for the MDBX proofs store. Empty defaults to `<datadir>/proofs-history`.
+  storagePath: ""
+  # -- On-disk store schema version. One of: "v1", "v2". v2 = history-aware reads at any block within the window.
+  storageVersion: v2
+  # -- Retention window in BLOCKS. Proofs accumulate forward from the init point (no backfill); older proofs are pruned. 1209600 = reth's MAX_ETH_PROOF_WINDOW cap (~14 days at 1s blocks).
+  window: 1209600
+  # -- Re-verification interval in blocks. 0 omits the flag (uses celo-reth's default).
+  verificationInterval: 0
+  # -- Minimum head block (from the headers static files) required before `proofs init` runs and the node launches with `--proofs-history`. Guards against initializing while the node is still doing its initial sync.
+  minSyncedBlock: 1
+
 s3config:
   image:
     repository: peakcom/s5cmd


### PR DESCRIPTION
## Summary

Adds an optional first-class `proofsHistory` feature to the op-reth chart (version `0.0.4` → `0.0.5`) that initializes the historical-proofs ExEx ("Bounded History Sidecar") store and launches the node with `--proofs-history`.

This generalizes the ad-hoc `extraInitContainers` + `extraArgs` wiring currently used in the celo-sepolia `op-reth-forno` deployment, and fixes that wiring's incompatibility with snapshot-bootstrapped datadirs.

## What's included

- **`proofsHistory.*` values** (feature off by default): `enabled`, `storagePath`, `storageVersion`, `window`, `verificationInterval`, `minSyncedBlock`.
- **`init-proofs-history` initContainer** (`_init-proofs-history.tpl`): runs `celo-reth proofs init` against the built-in chain spec (`config.chain`) rather than a downloaded `genesis.json`.
- **Marker-gated node flags**: the node only receives `--proofs-history …` once the store is initialized (`.proofs-initialized` marker), injected after `$natFlag` in the node exec line.

## Why the `config.chain` change matters

The store is anchored with `celo-reth proofs init --chain=<config.chain>` instead of `--chain=$datadir/genesis.json`. Snapshot-bootstrapped nodes share the `.initialized` marker and therefore skip `init-genesis`, so `genesis.json` is never downloaded — the old genesis-path init would fail there. Using the built-in chain spec makes the feature work for snapshot- and genesis-bootstrapped nodes alike.

## Sync guard

`proofs init` anchors at the current chain tip, so initializing mid initial-sync would anchor the store far behind the network. The init container parses the highest block from the headers static files (`static_file_headers_<start>_<end>`); if it is below `minSyncedBlock` it skips init and clears the marker (the node then launches without `--proofs-history`), and self-enables on a later restart once the node is synced.

## Verification

- `helm lint` → 0 failed
- `helm template`:
  - feature **off** → no init container / script / flags rendered
  - **on (defaults)** → `--proofs-history --proofs-history.storage-path=/celo/proofs-history --proofs-history.storage-version=v2 --proofs-history.window=1209600`
  - **on (custom)** → values propagate; `--proofs-history.verification-interval` rendered only when `> 0`
