### PR TITLE
feat(op-reth): add nodeMode to unify node prune flag and snapshot tier

### DIFF
--- a/charts/op-reth/Chart.yaml
+++ b/charts/op-reth/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 name: op-reth
 apiVersion: v2
-version: 0.0.5
+version: 0.0.6
 description: Celo implementation for op-reth execution engine (Optimism Rollup)
 home: https://clabs.co
 sources:

--- a/charts/op-reth/README.md
+++ b/charts/op-reth/README.md
@@ -1,6 +1,6 @@
 # op-reth
 
-![Version: 0.0.5](https://img.shields.io/badge/Version-0.0.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.0](https://img.shields.io/badge/AppVersion-v1.0.0-informational?style=flat-square)
+![Version: 0.0.6](https://img.shields.io/badge/Version-0.0.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.0](https://img.shields.io/badge/AppVersion-v1.0.0-informational?style=flat-square)
 
 Celo implementation for op-reth execution engine (Optimism Rollup)
 Initially based on [dysnix/charts/op-geth](https://github.com/dysnix/charts/tree/main/dysnix/op-geth).
@@ -31,7 +31,7 @@ Initially based on [dysnix/charts/op-geth](https://github.com/dysnix/charts/tree
 | config.chain | string | `"celo"` | Built-in chain name (e.g. celo, optimism, base) OR a path to a chain spec file. If empty, falls back to `$datadir/genesis.json`. |
 | config.datadir | string | `"/celo"` | Data directory inside the container. |
 | config.disableDiscovery | bool | `false` | Disable the peer discovery service entirely. |
-| config.full | bool | `true` | Run as full node (true) or archive node (false / ""). |
+| config.full | bool | `true` | DEPRECATED: prefer the top-level `nodeMode`. Run as full node (true) or archive node (false / ""). Ignored when `nodeMode` is set. |
 | config.http.api[0] | string | `"eth"` |  |
 | config.http.api[1] | string | `"net"` |  |
 | config.http.api[2] | string | `"web3"` |  |
@@ -122,6 +122,7 @@ Initially based on [dysnix/charts/op-geth](https://github.com/dysnix/charts/tree
 | livenessProbe.successThreshold | int | `1` |  |
 | livenessProbe.timeoutSeconds | int | `10` |  |
 | nameOverride | string | `""` |  |
+| nodeMode | string | `""` | Unified node mode driving BOTH the celo-reth node prune flag AND the snapshot download tier. One of "archive", "full" or "minimal": archive => no prune flag (full history) / download `--archive`; full => `--full` / download `--full`; minimal => `--minimal` / download `--minimal`. Empty ("") falls back to the deprecated `config.full` (node) and `snapshot.components` (download); when set, nodeMode supersedes both. Do not combine with `config.prune.*`. |
 | nodeSelector | object | `{}` |  |
 | persistence.hostPath.path | string | `"/blockchain/optimism"` | Host volume mount point. Assumes /blockchain is your host volume mount point. |
 | persistence.hostPath.type | string | `"DirectoryOrCreate"` | Automatically create the directory if it does not exist. |
@@ -207,7 +208,7 @@ Initially based on [dysnix/charts/op-geth](https://github.com/dysnix/charts/tree
 | services.rpc.wsPort | int | `8545` |  |
 | sidecarContainers | list | `[]` | Sidecar containers, can be templated |
 | snapshot | object | `{"components":"full","enabled":false,"extraArgs":[],"force":false,"manifestUrl":"","url":""}` | Bootstrap an empty datadir from a published snapshot using `celo-reth download` (manifest-based, served by default from snapshots.celo.org). This is an alternative to `init.genesis` / `initFromS3`; the init container runs before `init-genesis` and shares the `$datadir/.initialized` marker, so it is a no-op once the node is initialized and safe to leave enabled across restarts. |
-| snapshot.components | string | `"full"` | Component set to download. One of: "minimal", "full", "archive". Always passed so the interactive selection TUI is never triggered inside the init container. Use "archive" for archive nodes (`config.full: false`). |
+| snapshot.components | string | `"full"` | DEPRECATED: prefer the top-level `nodeMode`. Component set to download. One of: "minimal", "full", "archive". Used only when `nodeMode` is empty. Always passed so the interactive selection TUI is never triggered inside the init container. |
 | snapshot.enabled | bool | `false` | Enable the snapshot-download initContainer. |
 | snapshot.extraArgs | list | `[]` | Extra arguments appended to `celo-reth download` (can be templated). |
 | snapshot.force | bool | `false` | Re-download even if the datadir is already initialized (bypasses the `$datadir/.initialized` guard). |

--- a/charts/op-reth/templates/_helpers.tpl
+++ b/charts/op-reth/templates/_helpers.tpl
@@ -82,3 +82,36 @@ exec:
 {{- omit $root "enabled" | toYaml }}
 {{- end }}
 {{- end }}
+
+{{/*
+op-reth.nodeMode: effective node mode driving the celo-reth `--full` / `--minimal`
+prune flag. Precedence: an explicit .Values.nodeMode ("archive"|"full"|"minimal")
+wins; otherwise fall back to the deprecated .Values.config.full (true => "full"),
+defaulting to "archive" (no prune flag = full history).
+*/}}
+{{- define "op-reth.nodeMode" -}}
+{{- $mode := .Values.nodeMode | default "" -}}
+{{- if $mode -}}
+{{- if not (has $mode (list "archive" "full" "minimal")) -}}
+{{- fail (printf "nodeMode must be one of \"archive\", \"full\" or \"minimal\"; got %q" $mode) -}}
+{{- end -}}
+{{- $mode -}}
+{{- else if .Values.config.full -}}
+full
+{{- else -}}
+archive
+{{- end -}}
+{{- end -}}
+
+{{/*
+op-reth.snapshotComponents: snapshot tier passed to `celo-reth download`.
+Precedence: an explicit .Values.nodeMode wins; otherwise the deprecated
+.Values.snapshot.components.
+*/}}
+{{- define "op-reth.snapshotComponents" -}}
+{{- if .Values.nodeMode -}}
+{{- include "op-reth.nodeMode" . -}}
+{{- else -}}
+{{- .Values.snapshot.components -}}
+{{- end -}}
+{{- end -}}

--- a/charts/op-reth/templates/scripts/_init-from-snapshot.tpl
+++ b/charts/op-reth/templates/scripts/_init-from-snapshot.tpl
@@ -1,7 +1,8 @@
 #!/usr/bin/env sh
 set -e
-{{- if not (has .Values.snapshot.components (list "minimal" "full" "archive")) }}
-{{- fail (printf "snapshot.components must be one of \"minimal\", \"full\" or \"archive\"; got %q" .Values.snapshot.components) }}
+{{- $components := include "op-reth.snapshotComponents" . }}
+{{- if not (has $components (list "minimal" "full" "archive")) }}
+{{- fail (printf "snapshot download component (nodeMode or snapshot.components) must be one of \"minimal\", \"full\" or \"archive\"; got %q" $components) }}
 {{- end }}
 {{- if and .Values.snapshot.manifestUrl .Values.snapshot.url }}
 {{- fail "snapshot.manifestUrl and snapshot.url are mutually exclusive" }}
@@ -16,7 +17,7 @@ if [ -f "$datadir/.initialized" ]; then
 fi
 {{- end }}
 
-echo "Bootstrapping datadir from snapshot via 'celo-reth download --{{ .Values.snapshot.components }}'..."
+echo "Bootstrapping datadir from snapshot via 'celo-reth download --{{ $components }} --resumable'..."
 celo-reth download \
   --datadir={{ .Values.config.datadir }} \
 {{- if .Values.config.chain }}
@@ -28,13 +29,13 @@ celo-reth download \
 {{- with .Values.snapshot.url }}
   --url={{ . }} \
 {{- end }}
-  --force \
+  --resumable \
 {{- with .Values.snapshot.extraArgs }}
 {{- range . }}
   {{ tpl . $ }} \
 {{- end }}
 {{- end }}
-  --{{ .Values.snapshot.components }}
+  --{{ $components }}
 
 touch "$datadir/.initialized"
 echo "Snapshot download complete; datadir marked initialized."

--- a/charts/op-reth/templates/statefulset.yaml
+++ b/charts/op-reth/templates/statefulset.yaml
@@ -256,8 +256,11 @@ spec:
             --network-id={{ int . }} \
             {{- end }}
             --max-peers={{ .Values.config.maxpeers }} \
-            {{- with .Values.config.full }}
+            {{- $nodeMode := include "op-reth.nodeMode" . }}
+            {{- if eq $nodeMode "full" }}
             --full \
+            {{- else if eq $nodeMode "minimal" }}
+            --minimal \
             {{- end }}
             $nodeKeyFlag \
             {{- if .Values.config.disableDiscovery }}

--- a/charts/op-reth/values.yaml
+++ b/charts/op-reth/values.yaml
@@ -310,6 +310,15 @@ secrets:
     # -- Key inside `secretName` that holds the node key.
     secretKey: ""
 
+# -- Unified node mode driving BOTH the celo-reth node prune flag AND the snapshot
+# download tier. One of "archive", "full" or "minimal":
+# archive => no prune flag (full history) / download `--archive`;
+# full => `--full` / download `--full`;
+# minimal => `--minimal` / download `--minimal`.
+# Empty ("") falls back to the deprecated `config.full` (node) and `snapshot.components`
+# (download); when set, nodeMode supersedes both. Do not combine with `config.prune.*`.
+nodeMode: ""
+
 config:
   # -- Built-in chain name (e.g. celo, optimism, base) OR a path to a chain spec file. If empty, falls back to `$datadir/genesis.json`.
   chain: celo
@@ -333,7 +342,7 @@ config:
     port: 8551
   # -- Maximum total peers (inbound + outbound).
   maxpeers: 50
-  # -- Run as full node (true) or archive node (false / "").
+  # -- DEPRECATED: prefer the top-level `nodeMode`. Run as full node (true) or archive node (false / ""). Ignored when `nodeMode` is set.
   full: true
   # -- Disable the peer discovery service entirely.
   disableDiscovery: false
@@ -442,7 +451,7 @@ snapshot:
   enabled: false
   # -- Re-download even if the datadir is already initialized (bypasses the `$datadir/.initialized` guard).
   force: false
-  # -- Component set to download. One of: "minimal", "full", "archive". Always passed so the interactive selection TUI is never triggered inside the init container. Use "archive" for archive nodes (`config.full: false`).
+  # -- DEPRECATED: prefer the top-level `nodeMode`. Component set to download. One of: "minimal", "full", "archive". Used only when `nodeMode` is empty. Always passed so the interactive selection TUI is never triggered inside the init container.
   components: full
   # -- Override the snapshot manifest URL. Empty uses celo-reth's per-chain default (`https://snapshots.celo.org/mainnet/manifest.json` for chain `celo`, `https://snapshots.celo.org/celo-sepolia/manifest.json` for `celo-sepolia`). Mutually exclusive with `url`.
   manifestUrl: ""


### PR DESCRIPTION
## What

Adds a single top-level `nodeMode` value (`archive` | `full` | `minimal`) to the **op-reth** chart that drives **both**:

1. the `celo-reth` node prune flag — `--full` / `--minimal` / none (archive), and
2. the `celo-reth download` snapshot tier — `--full` / `--minimal` / `--archive`.

Previously these were two unrelated values (`config.full` for the node, `snapshot.components` for the download) that had to be kept consistent by hand.

## Behavior

| `nodeMode` | node prune flag | snapshot download |
|---|---|---|
| `archive` | _(none — full history)_ | `--archive` |
| `full` | `--full` | `--full` |
| `minimal` | `--minimal` | `--minimal` |
| `""` (unset) | falls back to `config.full` | falls back to `snapshot.components` |

`nodeMode` **supersedes** the now-deprecated `config.full` and `snapshot.components` when set. Both old values are retained as fallbacks when `nodeMode` is empty, so **this change is non-breaking** for existing consumers.

## Also in this PR

- **`--resumable` replaces the unconditional `--force`** on `celo-reth download`. The `snapshot.force` value (which bypasses the `$datadir/.initialized` guard) is unchanged — only the always-on per-run `--force` flag is swapped for resumable downloads.
- Two new helpers: `op-reth.nodeMode` and `op-reth.snapshotComponents` (with validation that rejects anything outside the three modes).
- Chart `0.0.5` → `0.0.6`; README regenerated via helm-docs.

## Validation

`helm template` across all paths (flag counts: download script renders in 2 locations, node flag in 1):

| Scenario | node prune flag | download tier | `--resumable` | `--force` |
|---|---|---|---|---|
| `nodeMode=full` | `--full` ✓ | `--full` | ✓ | **0** |
| `nodeMode=minimal` | `--minimal` ✓ | `--minimal` | ✓ | **0** |
| `nodeMode=archive` | none ✓ | `--archive` | ✓ | **0** |
| legacy `config.full=true` (no nodeMode) | `--full` ✓ | `--full` | ✓ | **0** |
| legacy `config.full=false` + `components=archive` | none ✓ | `--archive` | ✓ | **0** |

Archive correctly overrides the default `config.full: true`; the deprecated-fallback path renders identically to current behavior; `--force` is gone everywhere.

## Follow-up (separate, in `infrastructure`)

Once this is merged and a new chart version is published, `op-reth-forno-archive` will be migrated to consume `nodeMode: archive` + native `snapshot.enabled` (switching the archive node's bootstrap from genesis to snapshot) and drop its manual `extraArgs` / `extraInitContainers`.
