### PR TITLE
feat(succinct-game-monitor): support external secret env via secretKeyRef

### DIFF
--- a/charts/succinct-game-monitor/Chart.yaml
+++ b/charts/succinct-game-monitor/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: succinct-game-monitor
 description: A Helm chart for the succinct game monitor
 type: application
-version: 0.1.2
+version: 0.1.3
 appVersion: latest
 maintainers:
   - name: cLabs

--- a/charts/succinct-game-monitor/README.md
+++ b/charts/succinct-game-monitor/README.md
@@ -1,6 +1,6 @@
 # succinct-game-monitor
 
-![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 A Helm chart for the succinct game monitor
 
@@ -21,7 +21,7 @@ A Helm chart for the succinct game monitor
 | affinity | object | `{}` | Kubernetes pod affinity |
 | command | list | `["game-monitor"]` | Command to run in the container (overrides image ENTRYPOINT) |
 | config.env | object | `{"OP_SUCCINCT_MOCK":true,"RUST_LOG":"info","SP1_PROVER":"mock"}` | Environment variables to pass to the container These will be created as a ConfigMap and mounted as env vars |
-| config.secretEnv | string | `nil` | Secret environment variables to pass to the container These should be provided via a separate Secret resource |
+| config.secretEnv | string | `nil` | Secret environment variables to pass to the container These are rendered into a Secret resource created by THIS chart from the inline values below (so the values live in the release, e.g. git). Use for non-sensitive-in-git cases only. |
 | enableServiceLinks | bool | `false` | Kubernetes enableServiceLinks |
 | extraArgs | list | `["--logs-dir=/logs"]` | Extra arguments to pass to the binary      --env-file <ENV_FILE>          The environment file to use. This file should contain the following environment variables: [default: .env]      --poll-interval <POLL_INTERVAL>          The polling interval in seconds [default: 30]      --max-concurrent <MAX_CONCURRENT>          Maximum number of concurrent cost estimator processes [default: 5]      --cost-estimator-binary-path <COST_ESTIMATOR_BINARY_PATH>          The path to the cost estimator binary [default: cost-estimator]      --logs-dir <LOGS_DIR>          The directory under which to store the logs [default: logs]      --start-index <START_INDEX> |
 | fullnameOverride | string | `""` | Chart full name override |
@@ -44,6 +44,7 @@ A Helm chart for the succinct game monitor
 | readinessProbe | object | `{}` | Readiness probe configuration |
 | replicas | int | `1` | Number of replicas |
 | resources | object | `{}` | Container resources |
+| secretEnv | object | `{}` | External secret environment variables, injected from EXISTING Secret resources via secretKeyRef (NOT created by this chart). These are rendered before config.env, so config.env values may reference them with $(VAR) k8s dependent-env expansion. Example:   secretEnv:     HETZNER_FSN_API_KEY:       secretName: mainnet-cel2-secrets       secretKey: hetznerFsnApiKey |
 | securityContext | object | `{}` | Custom container security context |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.automount | bool | `true` | Automatically mount a ServiceAccount's API credentials? |

--- a/charts/succinct-game-monitor/templates/statefulset.yaml
+++ b/charts/succinct-game-monitor/templates/statefulset.yaml
@@ -41,8 +41,18 @@ spec:
           args:
             {{- toYaml .Values.extraArgs | nindent 12 }}
           {{- end }}
-          {{- if or (and .Values.config.env (not (empty .Values.config.env))) (and .Values.config.secretEnv (not (empty .Values.config.secretEnv))) }}
+          {{- if or (and .Values.secretEnv (not (empty .Values.secretEnv))) (and .Values.config.env (not (empty .Values.config.env))) (and .Values.config.secretEnv (not (empty .Values.config.secretEnv))) }}
           env:
+            {{- /* External secret refs are rendered first so that config.env values may
+                   reference them via $(VAR) k8s dependent-env expansion (a var can only
+                   reference other vars defined earlier in the same env list). */}}
+            {{- range $key, $value := .Values.secretEnv }}
+            - name: {{ $key }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $value.secretName }}
+                  key: {{ $value.secretKey }}
+            {{- end }}
             {{- range $key, $value := .Values.config.env }}
             - name: {{ $key }}
               value: {{ $value | quote }}

--- a/charts/succinct-game-monitor/values.yaml
+++ b/charts/succinct-game-monitor/values.yaml
@@ -50,7 +50,9 @@ config:
     # DISPUTE_GAME_FACTORY_ADDRESS:
 
   # -- Secret environment variables to pass to the container
-  # These should be provided via a separate Secret resource
+  # These are rendered into a Secret resource created by THIS chart from the
+  # inline values below (so the values live in the release, e.g. git). Use for
+  # non-sensitive-in-git cases only.
   secretEnv:
     # The below secret env vars are required.
     # L1_RPC:
@@ -58,6 +60,17 @@ config:
     # L2_RPC:
     # L2_NODE_RPC:
     # EIGENDA_PROXY_ADDRESS:
+
+# -- External secret environment variables, injected from EXISTING Secret
+# resources via secretKeyRef (NOT created by this chart). These are rendered
+# before config.env, so config.env values may reference them with $(VAR) k8s
+# dependent-env expansion.
+# Example:
+#   secretEnv:
+#     HETZNER_FSN_API_KEY:
+#       secretName: mainnet-cel2-secrets
+#       secretKey: hetznerFsnApiKey
+secretEnv: {}
 
 persistence:
   enabled: true


### PR DESCRIPTION
Adds a top-level `secretEnv` value to the `succinct-game-monitor` chart that injects env vars from EXISTING Secret resources via `secretKeyRef` (same shape as the `op-proxyd` chart), instead of only the inline `config.secretEnv` which creates a chart-owned Secret from values committed to git.

External secret envs are rendered before `config.env`, so `config.env` values can reference them with `$(VAR)` kubelet dependent-env expansion (e.g. an apikey injected into an RPC URL).

Bumps the chart version to `0.1.3`. README regenerated with helm-docs.

Consumed by the forno-eu `game-monitor` change that points its `L2_RPC` at the Hetzner fsn-1 op-reth gateway, which needs the apikey injected without committing it to git.