### PR TITLE
fix(op-reth): don't auto-anchor proofs-history behind the live tip on pruned nodes

### DIFF
--- a/charts/op-reth/Chart.yaml
+++ b/charts/op-reth/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 name: op-reth
 apiVersion: v2
-version: 0.0.6
+version: 0.0.7
 description: Celo implementation for op-reth execution engine (Optimism Rollup)
 home: https://clabs.co
 sources:

--- a/charts/op-reth/README.md
+++ b/charts/op-reth/README.md
@@ -1,6 +1,6 @@
 # op-reth
 
-![Version: 0.0.6](https://img.shields.io/badge/Version-0.0.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.0](https://img.shields.io/badge/AppVersion-v1.0.0-informational?style=flat-square)
+![Version: 0.0.7](https://img.shields.io/badge/Version-0.0.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.0](https://img.shields.io/badge/AppVersion-v1.0.0-informational?style=flat-square)
 
 Celo implementation for op-reth execution engine (Optimism Rollup)
 Initially based on [dysnix/charts/op-geth](https://github.com/dysnix/charts/tree/main/dysnix/op-geth).
@@ -85,8 +85,8 @@ Initially based on [dysnix/charts/op-geth](https://github.com/dysnix/charts/tree
 | extraVolumes | list | `[]` | Extra volumes, can be templated |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"Always"` |  |
-| image.repository | string | `"us-west1-docker.pkg.dev/devopsre/dev-images/celo-kona-reth"` |  |
-| image.tag | string | `"pr-144"` |  |
+| image.repository | string | `"us-west1-docker.pkg.dev/devopsre/celo-blockchain-public/op-reth"` |  |
+| image.tag | string | `"celo-v1.0.0@sha256:b0fdd2dcd0623faa5f1015eb6432b035397ba14ca84e64a76afc77b5f6909543"` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.http.annotations | object | `{}` |  |
 | ingress.http.className | string | `""` |  |
@@ -139,9 +139,10 @@ Initially based on [dysnix/charts/op-geth](https://github.com/dysnix/charts/tree
 | podLabels | object | `{}` | Extra pod labels |
 | podSecurityContext.fsGroup | int | `10001` |  |
 | podStatusLabels | object | `{}` | Labels marking the node as ready to serve traffic. Used as selector for the RPC service together with `.Values.podLabels` and default labels. |
-| proofsHistory | object | `{"enabled":false,"minSyncedBlock":1,"storagePath":"","storageVersion":"v2","verificationInterval":0,"window":1209600}` | Historical-proofs ExEx ("Bounded History Sidecar"): persists state/withdrawal proofs to a dedicated MDBX store and serves them via an `eth_getProof` override. A one-time, idempotent `celo-reth proofs init` initContainer anchors the store at the current chain tip (celo-reth refuses to launch with `--proofs-history` against an uninitialized store). Init is skipped while the node head is below `minSyncedBlock` (e.g. an empty datadir still doing initial sync), and the node only receives the `--proofs-history` flags once the store is initialized — so the feature is safe to leave enabled across restarts and for snapshot- or genesis-bootstrapped nodes. |
+| proofsHistory | object | `{"enabled":false,"init":{"initAtCurrentHead":false},"minSyncedBlock":1,"storagePath":"","storageVersion":"v2","verificationInterval":0,"window":1209600}` | Historical-proofs ExEx ("Bounded History Sidecar"): persists state/withdrawal proofs to a dedicated MDBX store and serves them via an `eth_getProof` override. A one-time, idempotent `celo-reth proofs init` initContainer anchors the store at the node's current canonical head (celo-reth refuses to launch with `--proofs-history` against an uninitialized store). The store only fills FORWARD from the anchor (no backfill), so the anchor MUST NOT sit behind the live network tip on a pruned node: archive nodes can backfill a gap, but full/minimal nodes cannot and the proof window then freezes forever. Archive nodes therefore initialize immediately; pruned nodes are NOT auto-initialized — they run without `--proofs-history` until `init.initAtCurrentHead` is set (see below). The node only receives the `--proofs-history` flags once the store is initialized, so the feature is safe to leave enabled across restarts. |
 | proofsHistory.enabled | bool | `false` | Enable the proofs-history init container and node flags. |
-| proofsHistory.minSyncedBlock | int | `1` | Minimum head block (from the headers static files) required before `proofs init` runs and the node launches with `--proofs-history`. Guards against initializing while the node is still doing its initial sync. |
+| proofsHistory.init.initAtCurrentHead | bool | `false` | Allow a full/minimal (pruned) node to run `proofs init` at its current canonical head. A pruned node cannot backfill a gap between the proof anchor and the live tip, so its store must be anchored AT the live tip; because the init container cannot detect live-tip sync on its own, pruned nodes are NOT auto-initialized. Run the node until it is fully synced to the tip, then set this `true` and restart to anchor at the current head. Ignored by archive nodes (they initialize immediately and can backfill). To re-anchor an already-wedged store, delete the proofs store dir and `<datadir>/.proofs-initialized` first, then restart. |
+| proofsHistory.minSyncedBlock | int | `1` | Minimum head block (from the headers static files) required before `proofs init` runs and the node launches with `--proofs-history`. Guards against initializing while the node is still doing its initial sync. Coarse (static-file granularity), so it does not by itself protect a pruned node from anchoring behind the live tip — see `init.initAtCurrentHead`. |
 | proofsHistory.storagePath | string | `""` | Filesystem path for the MDBX proofs store. Empty defaults to `<datadir>/proofs-history`. |
 | proofsHistory.storageVersion | string | `"v2"` | On-disk store schema version. One of: "v1", "v2". v2 = history-aware reads at any block within the window. |
 | proofsHistory.verificationInterval | int | `0` | Re-verification interval in blocks. 0 omits the flag (uses celo-reth's default). |

--- a/charts/op-reth/templates/scripts/_init-proofs-history.tpl
+++ b/charts/op-reth/templates/scripts/_init-proofs-history.tpl
@@ -4,6 +4,27 @@ set -e
 datadir="{{ .Values.persistence.mountPath | default .Values.config.datadir }}"
 storagePath="{{ .Values.proofsHistory.storagePath | default (printf "%s/proofs-history" .Values.config.datadir) }}"
 minSyncedBlock={{ .Values.proofsHistory.minSyncedBlock | int64 }}
+nodeMode="{{ include "op-reth.nodeMode" . }}"
+
+# "proofs init" anchors the proofs store at the node's CURRENT canonical head and only fills
+# FORWARD from there; it never backfills. If the anchor lands behind the live network tip, the
+# ExEx must catch up by re-executing the skipped blocks:
+#   * archive nodes retain all history, so catch-up (and "proofs backfill") works -> anchoring at
+#     a local/snapshot head behind the tip is safe.
+#   * full/minimal (pruned) nodes prune historical state beyond the prune distance, so a gap
+#     between the anchor and the live tip is UNRECOVERABLE: catch-up fails (NonceTooLow) and the
+#     proof window freezes at the anchor forever.
+# This init container runs BEFORE the node, so it cannot observe whether the datadir is actually
+# caught up to the live NETWORK tip (a snapshot restore leaves it hundreds of thousands of blocks
+# behind). We therefore refuse to auto-anchor a pruned node: it runs WITHOUT --proofs-history until
+# an operator confirms the node is fully synced and sets "proofsHistory.init.initAtCurrentHead=true"
+# (then restarts), at which point the store is anchored at the now-current head.
+if [ ! -f "$datadir/.proofs-initialized" ] && { [ "$nodeMode" = "full" ] || [ "$nodeMode" = "minimal" ]; } && [ "{{ .Values.proofsHistory.init.initAtCurrentHead }}" != "true" ]; then
+  echo "proofs-history: pruned node ($nodeMode) not auto-initialized to avoid anchoring the proof window behind the live tip (pruned nodes cannot backfill the gap)."
+  echo "proofs-history: sync the node fully to the live tip, then set 'proofsHistory.init.initAtCurrentHead=true' and restart. (Archive nodes bootstrap hands-off.)"
+  rm -f "$datadir/.proofs-initialized"
+  exit 0
+fi
 
 # Highest block present in the headers static files (reth names them
 # "static_file_headers_<start>_<end>"). Cheap "is the node synced?" probe that avoids

--- a/charts/op-reth/values.yaml
+++ b/charts/op-reth/values.yaml
@@ -1,7 +1,7 @@
 ---
 image:
-  repository: us-west1-docker.pkg.dev/devopsre/dev-images/celo-kona-reth
-  tag: pr-144
+  repository: us-west1-docker.pkg.dev/devopsre/celo-blockchain-public/op-reth
+  tag: celo-v1.0.0@sha256:b0fdd2dcd0623faa5f1015eb6432b035397ba14ca84e64a76afc77b5f6909543
   pullPolicy: Always
 
 imagePullSecrets: []
@@ -462,11 +462,14 @@ snapshot:
 
 # -- Historical-proofs ExEx ("Bounded History Sidecar"): persists state/withdrawal proofs to a
 # dedicated MDBX store and serves them via an `eth_getProof` override. A one-time, idempotent
-# `celo-reth proofs init` initContainer anchors the store at the current chain tip (celo-reth
-# refuses to launch with `--proofs-history` against an uninitialized store). Init is skipped while
-# the node head is below `minSyncedBlock` (e.g. an empty datadir still doing initial sync), and the
-# node only receives the `--proofs-history` flags once the store is initialized — so the feature is
-# safe to leave enabled across restarts and for snapshot- or genesis-bootstrapped nodes.
+# `celo-reth proofs init` initContainer anchors the store at the node's current canonical head
+# (celo-reth refuses to launch with `--proofs-history` against an uninitialized store). The store
+# only fills FORWARD from the anchor (no backfill), so the anchor MUST NOT sit behind the live
+# network tip on a pruned node: archive nodes can backfill a gap, but full/minimal nodes cannot and
+# the proof window then freezes forever. Archive nodes therefore initialize immediately; pruned
+# nodes are NOT auto-initialized — they run without `--proofs-history` until `init.initAtCurrentHead`
+# is set (see below). The node only receives the `--proofs-history` flags once the store is
+# initialized, so the feature is safe to leave enabled across restarts.
 proofsHistory:
   # -- Enable the proofs-history init container and node flags.
   enabled: false
@@ -478,8 +481,11 @@ proofsHistory:
   window: 1209600
   # -- Re-verification interval in blocks. 0 omits the flag (uses celo-reth's default).
   verificationInterval: 0
-  # -- Minimum head block (from the headers static files) required before `proofs init` runs and the node launches with `--proofs-history`. Guards against initializing while the node is still doing its initial sync.
+  # -- Minimum head block (from the headers static files) required before `proofs init` runs and the node launches with `--proofs-history`. Guards against initializing while the node is still doing its initial sync. Coarse (static-file granularity), so it does not by itself protect a pruned node from anchoring behind the live tip — see `init.initAtCurrentHead`.
   minSyncedBlock: 1
+  init:
+    # -- Allow a full/minimal (pruned) node to run `proofs init` at its current canonical head. A pruned node cannot backfill a gap between the proof anchor and the live tip, so its store must be anchored AT the live tip; because the init container cannot detect live-tip sync on its own, pruned nodes are NOT auto-initialized. Run the node until it is fully synced to the tip, then set this `true` and restart to anchor at the current head. Ignored by archive nodes (they initialize immediately and can backfill). To re-anchor an already-wedged store, delete the proofs store dir and `<datadir>/.proofs-initialized` first, then restart.
+    initAtCurrentHead: false
 
 s3config:
   image:


### PR DESCRIPTION
## Problem

On a **pruned** op-reth node (`nodeMode: full`/`minimal`) with `proofsHistory.enabled: true`, the proof window freezes and never collects blocks. Observed on **forno-europe**: the ExEx window is stuck ~93k blocks behind the chain head and has advanced **zero** blocks for over a day.

## Root cause

`celo-reth proofs init` (run by the `init-proofs-history` container) anchors the proofs store at the node's **current canonical head** and then only fills **forward** — it never backfills. The container runs *before* the node and gates purely on `minSyncedBlock` (default `1`), so on a snapshot-bootstrapped node it anchors immediately at the **snapshot tip**, which is far behind the live network tip.

- **Archive** nodes recover fine: they retain all history, so the ExEx backfills the gap up to the tip.
- **Pruned** (`--full`/`--minimal`) nodes **cannot**: the historical state for the gap has been pruned, so catch-up re-execution fails with `NonceTooLow` and the window is stuck at the anchor **forever**.

The init container can't observe whether the datadir is caught up to the live *network* tip (the node isn't running yet), so it must not auto-anchor a pruned node.

## Fix

Make the proofs bootstrap **mode-aware** (`templates/scripts/_init-proofs-history.tpl`):

- **archive** → initialize immediately at the local head (unchanged behavior).
- **full / minimal (pruned)** → **not auto-initialized**. The node runs *without* `--proofs-history` until an operator confirms it is fully synced to the tip and sets **`proofsHistory.init.initAtCurrentHead: true`**, then restarts — at which point the store is anchored at the (now caught-up) head. `celo-reth proofs init` opens the DB with `RoInconsistent`, so anchoring a live/running datadir is safe.

This is safe-by-default: it cannot break archive nodes, proofs-disabled nodes, or already-initialized nodes, and it replaces the silent wedge with a healthy node running without proofs until deliberately enabled.

### New value
```yaml
proofsHistory:
  init:
    initAtCurrentHead: false   # set true on a pruned node ONLY once it is fully synced to the tip
```

### Also
- Default image → released `celo-blockchain-public/op-reth:celo-v1.0.0@sha256:b0fdd2…` (includes the merged snapshot-checkpoint fix + `RoInconsistent` proofs init) — replaces the `dev-images/celo-kona-reth:pr-144` dev tag.
- Chart `0.0.6` → `0.0.7`; README regenerated via helm-docs.

## Recovering an already-wedged node (e.g. forno-europe)

The store is already anchored behind the tip, so this fix alone won't un-wedge it. One-time recovery: delete the proofs store dir + marker so it re-initializes cleanly, with the node already synced:
```sh
# in the op-reth container / on the datadir PVC
rm -rf /celo/proofs-history /celo/.proofs-initialized
# then deploy with proofsHistory.init.initAtCurrentHead: true and restart
```

## Validation

- `helm lint` ✅
- `helm template` with the forno-eu (full) values and an `nodeMode=archive` variant ✅ — pruned render skips init; archive render initializes.
- `sh -n` on the rendered init script ✅
- README regenerated (helm-docs) ✅

Not yet runtime-tested on a live cluster — happy to validate on forno-europe once released.

## Answer to "does proofs need archive?"
Proofs-history works on a pruned node **for live forward-fill** (it builds proofs from each live notification, not from pruned history), but only if the store is anchored **at** the live tip and the node never falls more than the prune distance behind. Snapshot-bootstrap-then-backfill fundamentally needs **archive**. Archive is the hands-off, robust choice; pruned works with this fix + `initAtCurrentHead` once synced.
