### PR TITLE
feat(mcp-server): read all resources except secrets

### DIFF
--- a/charts/mcp-server/Chart.yaml
+++ b/charts/mcp-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mcp-server
 description: A Helm chart for MCP Server flux159/mcp-server-kubernetes
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: "v2.9.7"
 home: https://clabs.co
 sources:

--- a/charts/mcp-server/README.md
+++ b/charts/mcp-server/README.md
@@ -1,6 +1,6 @@
 # mcp-server
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.9.7](https://img.shields.io/badge/AppVersion-v2.9.7-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.9.7](https://img.shields.io/badge/AppVersion-v2.9.7-informational?style=flat-square)
 
 A Helm chart for MCP Server flux159/mcp-server-kubernetes
 

--- a/charts/mcp-server/templates/clusterrole.yaml
+++ b/charts/mcp-server/templates/clusterrole.yaml
@@ -46,11 +46,14 @@ rules:
       - "events.k8s.io"
       - "flowcontrol.apiserver.k8s.io"
       - "gateway.networking.k8s.io"
+      - "internal.apiserver.k8s.io"
       - "networking.k8s.io"
       - "node.k8s.io"
       - "policy"
       - "rbac.authorization.k8s.io"
+      - "resource.k8s.io"
       - "scheduling.k8s.io"
       - "storage.k8s.io"
+      - "storagemigration.k8s.io"
     resources: ["*"]
     verbs: ["get", "list", "watch"]

--- a/charts/mcp-server/templates/clusterrole.yaml
+++ b/charts/mcp-server/templates/clusterrole.yaml
@@ -5,24 +5,52 @@ metadata:
   labels:
     {{- include "mcp-server.labels" . | nindent 4 }}
 rules:
+  # Core API group (""): read every core resource EXCEPT secrets.
+  # RBAC has no deny rule, so secrets are excluded by simply not granting
+  # them here. A wildcard over resources would re-include secrets, so the
+  # core resources are enumerated explicitly.
   - apiGroups: [""]
     resources:
-      - pods
-      - services
+      - bindings
+      - componentstatuses
       - configmaps
       - endpoints
-      - persistentvolumeclaims
-      - persistentvolumes
-      - replicationcontrollers
+      - events
+      - limitranges
       - namespaces
       - nodes
-      - events
-      - resourcequotas
-      - limitranges
-      - bindings
+      - persistentvolumeclaims
+      - persistentvolumes
+      - pods
+      - pods/log
       - podtemplates
+      - replicationcontrollers
+      - resourcequotas
       - serviceaccounts
+      - services
     verbs: ["get", "list", "watch"]
-  - apiGroups: ["apps"]
+  # Non-core API groups: wildcard read. Secrets live only in the core group,
+  # so wildcarding resources here cannot expose them. Covers CRDs
+  # (apiextensions.k8s.io) and the Gateway API used for routing. Add any
+  # custom CRD API group needed for read access to this list.
+  - apiGroups:
+      - "admissionregistration.k8s.io"
+      - "apiextensions.k8s.io"
+      - "apiregistration.k8s.io"
+      - "apps"
+      - "autoscaling"
+      - "batch"
+      - "certificates.k8s.io"
+      - "coordination.k8s.io"
+      - "discovery.k8s.io"
+      - "events.k8s.io"
+      - "flowcontrol.apiserver.k8s.io"
+      - "gateway.networking.k8s.io"
+      - "networking.k8s.io"
+      - "node.k8s.io"
+      - "policy"
+      - "rbac.authorization.k8s.io"
+      - "scheduling.k8s.io"
+      - "storage.k8s.io"
     resources: ["*"]
     verbs: ["get", "list", "watch"]


### PR DESCRIPTION
## What

Broadens the `mcp-server` ClusterRole to `get`/`list`/`watch` across the core API group and all standard non-core API groups (incl. `apiextensions.k8s.io` for CRDs and `gateway.networking.k8s.io`). Bumps chart `0.1.0 -> 0.2.0`.

## Why

The role only granted a fixed subset of core + `apps` resources. Reads of CRDs and other groups were denied, e.g.:

```
customresourcedefinitions.apiextensions.k8s.io is forbidden:
User "system:serviceaccount:mcp-server:mcp-server" cannot list resource
"customresourcedefinitions" in API group "apiextensions.k8s.io" at the cluster scope
```

## Secrets excluded — by construction

Kubernetes RBAC is additive (no deny). `secrets` exist **only** in the core group, so:
- **core group** enumerates every resource **except `secrets`** (a resource wildcard would re-include them).
- **non-core groups** wildcard resources safely — no `secrets` there.

Result: the mcp-server ServiceAccount cannot read Secret objects at the RBAC layer, on top of the app-level Secret masking in mcp-server v4 (GHSA-w23h-64x4-22h9). Two independent barriers.

## Coverage limitation

Non-core groups are an explicit list of standard Kubernetes groups + Gateway API. **Custom third-party CRD API groups** (e.g. `cert-manager.io`, `monitoring.coreos.com`) are not included — append them to the second rule as needed. This is the trade-off for keeping `secrets` hard-excluded (a `["*"]`/`["*"]` rule would cover everything but re-expose Secrets to RBAC).

## Rollout

Consumed via ApplicationSet in `celo-org/infrastructure` (`argocd/applicationsets/apps/devopsre/mcp-server.yaml`), which pins chart `targetRevision: 0.1.0`. **After this merges + the OCI chart publishes, that pin must bump to `0.2.0`** for the new RBAC to reach the 5 clusters.

## Test

- `helm lint charts/mcp-server` → 0 failed
- `helm template` renders the ClusterRole as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)