### PR TITLE
feat(mcp-server): read all observed CRD API groups except secrets

### DIFF
--- a/charts/mcp-server/Chart.yaml
+++ b/charts/mcp-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mcp-server
 description: A Helm chart for MCP Server flux159/mcp-server-kubernetes
 type: application
-version: 0.2.0
+version: 0.3.0
 appVersion: "v2.9.7"
 home: https://clabs.co
 sources:

--- a/charts/mcp-server/README.md
+++ b/charts/mcp-server/README.md
@@ -1,6 +1,6 @@
 # mcp-server
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.9.7](https://img.shields.io/badge/AppVersion-v2.9.7-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.9.7](https://img.shields.io/badge/AppVersion-v2.9.7-informational?style=flat-square)
 
 A Helm chart for MCP Server flux159/mcp-server-kubernetes
 

--- a/charts/mcp-server/templates/clusterrole.yaml
+++ b/charts/mcp-server/templates/clusterrole.yaml
@@ -43,7 +43,6 @@ rules:
       - "apiextensions.k8s.io"
       - "apiregistration.k8s.io"
       - "apps"
-      - "aquasecurity.github.io"
       - "auto.gke.io"
       - "autoscaling"
       - "autoscaling.gke.io"
@@ -91,4 +90,25 @@ rules:
       - "storagemigration.k8s.io"
       - "warden.gke.io"
     resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  # Aqua Trivy Operator (aquasecurity.github.io): granted separately with
+  # enumerated resources rather than a resource wildcard, so that
+  # exposedsecretreports -- which record secret material discovered in
+  # images/workloads -- stay excluded, consistent with the core-group
+  # Secret exclusion. Add new Aqua report types here as needed, but do NOT
+  # add exposedsecretreports.
+  - apiGroups:
+      - "aquasecurity.github.io"
+    resources:
+      - clustercompliancereports
+      - clusterconfigauditreports
+      - clusterinfraassessmentreports
+      - clusterrbacassessmentreports
+      - clustersbomreports
+      - clustervulnerabilityreports
+      - configauditreports
+      - infraassessmentreports
+      - rbacassessmentreports
+      - sbomreports
+      - vulnerabilityreports
     verbs: ["get", "list", "watch"]

--- a/charts/mcp-server/templates/clusterrole.yaml
+++ b/charts/mcp-server/templates/clusterrole.yaml
@@ -30,30 +30,65 @@ rules:
       - services
     verbs: ["get", "list", "watch"]
   # Non-core API groups: wildcard read. Secrets live only in the core group,
-  # so wildcarding resources here cannot expose them. Covers CRDs
-  # (apiextensions.k8s.io) and the Gateway API used for routing. Add any
-  # custom CRD API group needed for read access to this list.
+  # so wildcarding resources here cannot expose them. Covers the standard
+  # built-in groups plus every custom CRD API group observed across the
+  # target clusters: GKE platform, cert-manager, external-secrets, Envoy
+  # and Gateway API, monitoring (Prometheus operator, Grafana, Google
+  # Managed Prometheus), Trivy, Kong and others.
+  # Listing a group that is absent on a given cluster is a harmless no-op;
+  # add new CRD API groups here as they appear.
   - apiGroups:
+      - "acme.cert-manager.io"
       - "admissionregistration.k8s.io"
       - "apiextensions.k8s.io"
       - "apiregistration.k8s.io"
       - "apps"
+      - "aquasecurity.github.io"
+      - "auto.gke.io"
       - "autoscaling"
+      - "autoscaling.gke.io"
+      - "autoscaling.k8s.io"
+      - "autoscaling.x-k8s.io"
       - "batch"
+      - "cert-manager.io"
       - "certificates.k8s.io"
+      - "cloud.google.com"
+      - "configuration.konghq.com"
       - "coordination.k8s.io"
+      - "datalayer.gke.io"
       - "discovery.k8s.io"
       - "events.k8s.io"
+      - "external-secrets.io"
       - "flowcontrol.apiserver.k8s.io"
+      - "gateway.envoyproxy.io"
       - "gateway.networking.k8s.io"
+      - "gateway.networking.x-k8s.io"
+      - "generators.external-secrets.io"
+      - "hub.gke.io"
+      - "inference.networking.k8s.io"
       - "internal.apiserver.k8s.io"
+      - "internal.autoscaling.gke.io"
+      - "internal.autoscaling.k8s.io"
+      - "migration.k8s.io"
+      - "monitoring.coreos.com"
+      - "monitoring.gke.io"
+      - "monitoring.googleapis.com"
+      - "monitoring.grafana.com"
+      - "networking.gke.io"
       - "networking.k8s.io"
+      - "node.gke.io"
       - "node.k8s.io"
+      - "nodemanagement.gke.io"
       - "policy"
+      - "policy.sigstore.dev"
       - "rbac.authorization.k8s.io"
       - "resource.k8s.io"
+      - "scalingpolicy.kope.io"
       - "scheduling.k8s.io"
+      - "security.cloud.google.com"
+      - "snapshot.storage.k8s.io"
       - "storage.k8s.io"
       - "storagemigration.k8s.io"
+      - "warden.gke.io"
     resources: ["*"]
     verbs: ["get", "list", "watch"]


### PR DESCRIPTION
## What

Extends the `mcp-server` ClusterRole non-core read rule from the standard built-in groups to **every custom CRD API group observed across the 5 mcp-server clusters**. Chart `0.2.0 -> 0.3.0`. Non-core group count: 21 -> 52.

## Why

`0.2.0` granted `apiextensions.k8s.io` (so the CRD *definitions* list) + standard built-in groups. But the **custom resource objects** still 403'd, because their API groups weren't granted. Verified live across clusters, e.g. `servicemonitors.monitoring.coreos.com`, `vulnerabilityreports.aquasecurity.github.io`, `verticalpodautoscalers.autoscaling.k8s.io`, `externalsecrets.external-secrets.io`, `kongplugins.configuration.konghq.com`.

## Groups added

GKE platform (`cloud.google.com`, `networking.gke.io`, `auto.gke.io`, `warden.gke.io`, `hub.gke.io`, `node.gke.io`, `datalayer.gke.io`, `nodemanagement.gke.io`, `security.cloud.google.com`, `autoscaling.gke.io`, `internal.autoscaling.gke.io`), autoscaling (`autoscaling.k8s.io` VPA, `autoscaling.x-k8s.io`, `internal.autoscaling.k8s.io`, `scalingpolicy.kope.io`), cert-manager (`cert-manager.io`, `acme.cert-manager.io`), external-secrets (`external-secrets.io`, `generators.external-secrets.io`), Envoy/Gateway (`gateway.envoyproxy.io`, `gateway.networking.x-k8s.io`), monitoring (`monitoring.coreos.com`, `monitoring.grafana.com`, `monitoring.googleapis.com`, `monitoring.gke.io`), `aquasecurity.github.io` (Trivy), `configuration.konghq.com` (Kong), `policy.sigstore.dev`, `snapshot.storage.k8s.io`, `inference.networking.k8s.io`, `migration.k8s.io`.

## Safety

- **Secrets still excluded** — all additions are non-core groups; `secrets` exist only in the core group, which stays enumerated without them. Verified `kubectl get secrets` returns Forbidden on all 5 clusters under the current role.
- **Absent groups are no-ops** — RBAC `apiGroups` are plain string matchers, not references. A group not installed on a given cluster simply never matches; no error, no dependency. This makes the union safe as a single shared chart across heterogeneous clusters.

## Rollout

After merge + OCI publish as `0.3.0`, bump `targetRevision` to `0.3.0` in `celo-org/infrastructure` (`argocd/applicationsets/apps/devopsre/mcp-server.yaml`).

## Test

- `helm lint charts/mcp-server` -> 0 failed
- `helm template` renders 52 non-core groups, no duplicates

🤖 Generated with [Claude Code](https://claude.com/claude-code)