### PR TITLE
fix(mcp-server): grant read on metrics.k8s.io API group

### DIFF
--- a/charts/mcp-server/Chart.yaml
+++ b/charts/mcp-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mcp-server
 description: A Helm chart for MCP Server flux159/mcp-server-kubernetes
 type: application
-version: 0.3.0
+version: 0.3.1
 appVersion: "v2.9.7"
 home: https://clabs.co
 sources:

--- a/charts/mcp-server/README.md
+++ b/charts/mcp-server/README.md
@@ -1,6 +1,6 @@
 # mcp-server
 
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.9.7](https://img.shields.io/badge/AppVersion-v2.9.7-informational?style=flat-square)
+![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.9.7](https://img.shields.io/badge/AppVersion-v2.9.7-informational?style=flat-square)
 
 A Helm chart for MCP Server flux159/mcp-server-kubernetes
 

--- a/charts/mcp-server/templates/clusterrole.yaml
+++ b/charts/mcp-server/templates/clusterrole.yaml
@@ -34,7 +34,8 @@ rules:
   # built-in groups plus every custom CRD API group observed across the
   # target clusters: GKE platform, cert-manager, external-secrets, Envoy
   # and Gateway API, monitoring (Prometheus operator, Grafana, Google
-  # Managed Prometheus), Trivy, Kong and others.
+  # Managed Prometheus), the metrics-server aggregated API backing
+  # `kubectl top` (metrics.k8s.io), Trivy, Kong and others.
   # Listing a group that is absent on a given cluster is a harmless no-op;
   # add new CRD API groups here as they appear.
   - apiGroups:
@@ -68,6 +69,7 @@ rules:
       - "internal.apiserver.k8s.io"
       - "internal.autoscaling.gke.io"
       - "internal.autoscaling.k8s.io"
+      - "metrics.k8s.io"
       - "migration.k8s.io"
       - "monitoring.coreos.com"
       - "monitoring.gke.io"


### PR DESCRIPTION
## Problem

Kubernetes MCP server calls against node or pod metrics fail with a Forbidden error:

```
Error from server (Forbidden): nodes.metrics.k8s.io "gke-rc1-us-west1-c2d-standard-8-spot--9cb3e2f1-cb87"
is forbidden: User "system:serviceaccount:mcp-server:mcp-server" cannot get
resource "nodes" in API group "metrics.k8s.io" at the cluster scope
```

`nodes.metrics.k8s.io` is served by the metrics-server aggregated API, a distinct API group from core `nodes`. The ClusterRole grants core `nodes` (get/list/watch) and wildcards the observed non-core API groups, but `metrics.k8s.io` was never in that list — so `nodes.metrics.k8s.io` and `pods.metrics.k8s.io` (what `kubectl top` reads) were unreachable.

Verified against the live object on the `forno-us` cluster (`clusterrole/mcp-server`, chart `mcp-server-0.3.0`, tracked by ArgoCD as `mcp-server-forno-us`): the group is absent there too, so this affects every cluster running the chart.

## Change

- Add `metrics.k8s.io` to the non-core read rule in `templates/clusterrole.yaml`
- Bump chart version `0.3.0` → `0.3.1`

## Security

`metrics.k8s.io` serves only `nodes` and `pods` metrics resources (CPU/memory samples). The existing `resources: ["*"]` on that rule therefore exposes no secret-adjacent data, and the core-group Secret exclusion plus the `aquasecurity.github.io` `exposedsecretreports` carve-out are unaffected. Verbs stay `get`/`list`/`watch`.

## Testing

- `helm lint charts/mcp-server` — 1 chart linted, 0 failed
- `helm template` renders the new group in the ClusterRole

🤖 Generated with [Claude Code](https://claude.com/claude-code)